### PR TITLE
add monthid to DateParametrization templates

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/DateParameterization.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/DateParameterization.scala
@@ -187,6 +187,7 @@ trait MonthlyParameterization {
   val year: Parameter[String]
   val month: Parameter[String]
   import DateParameterizationUtils._
+  val monthId: Parameter[String] = p(s"${year.v.get}${month.v.get}")
 
   def prevMonth() = DateParameterizationUtils.prevMonth(year, month)
 


### PR DESCRIPTION
Having a separate monthid field (even if renundant) will speed up certain hive queries
