### PR TITLE
Feature shell transformation: use scala.sys.process._

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
@@ -26,7 +26,6 @@ class ShellDriver(val driverRunCompletionHandlerClassNames: List[String]) extend
     })
  
   def doRun(t: ShellTransformation): DriverRunState[ShellTransformation] = {
-    log.error("test")
     val stdout = new StringBuilder
     try {
       val returnCode = if (t.scriptFile != "")
@@ -37,8 +36,7 @@ class ShellDriver(val driverRunCompletionHandlerClassNames: List[String]) extend
         scala.compat.Platform.collectGarbage() // JVM Windows related bug workaround JDK-4715154
         file.deleteOnExit()
         Process(Seq(t.shell, file.getAbsolutePath), None, t.env.toSeq: _*).!(ProcessLogger(stdout append _,log.error(_)))
-      }
-    // println(stdout.takeRight(100))
+      }  
       if (returnCode == 0)
         DriverRunSucceeded[ShellTransformation](this, "Shell script finished")
       else

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
@@ -11,11 +11,14 @@ import scala.collection.JavaConversions.mapAsJavaMap
 import java.lang.InterruptedException
 import java.io.File
 import java.io.FileWriter
+import scala.sys.process._
+import org.slf4j.LoggerFactory
 
 class ShellDriver(val driverRunCompletionHandlerClassNames: List[String]) extends Driver[ShellTransformation] {
   override def transformationName = "shell"
 
   implicit val executionContext = Settings().system.dispatchers.lookup("akka.actor.future-driver-dispatcher")
+  val log = LoggerFactory.getLogger(classOf[ShellDriver])
 
   def run(t: ShellTransformation): DriverRunHandle[ShellTransformation] =
     new DriverRunHandle(this, new LocalDateTime(), t, future {
@@ -24,24 +27,15 @@ class ShellDriver(val driverRunCompletionHandlerClassNames: List[String]) extend
 
   def doRun(t: ShellTransformation): DriverRunState[ShellTransformation] = {
     try {
-
-      val pb = if (t.scriptFile != "")
-        new ProcessBuilder(t.shell, t.scriptFile)
+      val returnCode = if (t.scriptFile != "")
+        Process(Seq(t.shell, t.scriptFile), None, t.env.toSeq: _*).!(ProcessLogger(line => log.error(line)))
       else {
         val file = File.createTempFile("_schedoscope", ".sh")
         using(new FileWriter(file))(writer => { writer.write(s"#!${t.shell}\n"); t.script.foreach(line => writer.write(line)) })
         scala.compat.Platform.collectGarbage() // JVM Windows related bug workaround JDK-4715154
         file.deleteOnExit()
-        new ProcessBuilder(t.shell, file.getCanonicalPath())
-
+        Process(Seq(t.shell, file.getAbsolutePath), None, t.env.toSeq: _*).!(ProcessLogger(line => log.error(line)))
       }
-
-      val env = pb.environment()
-      env.putAll(t.env)
-
-      val process = pb.start()
-      val returnCode = process.waitFor()
-
       if (returnCode == 0)
         DriverRunSucceeded[ShellTransformation](this, "Shell script finished")
       else

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/ShellDriverTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/ShellDriverTest.scala
@@ -9,6 +9,8 @@ import com.typesafe.config.ConfigFactory
 import org.schedoscope.ShellTests
 import org.schedoscope.test.resources.LocalTestResources
 import org.schedoscope.test.resources.TestDriverRunCompletionHandlerCallCounter.driverRunCompletionHandlerCalled
+import java.io.File
+import scala.io.Source
 
 class ShellDriverTest extends FlatSpec with Matchers {
 
@@ -25,10 +27,17 @@ class ShellDriverTest extends FlatSpec with Matchers {
   }
 
   it should "execute another shell tranformations synchronously" taggedAs (DriverTests, ShellTests) in {
-    val driverRunState = driver.runAndWait(ShellTransformation("echo test >> /tmp/testout"))
+    val driverRunState = driver.runAndWait(ShellTransformation("echo error >/dev/stderr;zcat /usr/share/man/man1/*gz"))
     driverRunState shouldBe a[DriverRunSucceeded[_]]
   }
-
+  
+  it should "pass environment to the shell" taggedAs (DriverTests, ShellTests) in {
+    val file = File.createTempFile("_schedoscope", ".sh")
+        file.deleteOnExit()
+    val driverRunState = driver.runAndWait(ShellTransformation("echo $testvar"+s">${file.getAbsolutePath()}",env=Map("testvar" -> "foobar")))
+    Source.fromFile(file).getLines.next shouldBe "foobar"   
+    driverRunState shouldBe a[DriverRunSucceeded[_]]
+  }
   it should "execute pig tranformations and return errors when running synchronously" taggedAs (DriverTests, ShellTests) in {
     val driverRunState = driver.runAndWait(ShellTransformation("exit 1"))
 


### PR DESCRIPTION
Replaced Java ProcessBuilder with proper Scala implementation.  Standard output gets discarded, stderr gets logged. Fixes #14 .
