### PR TITLE
Scala version migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .project
 .classpath
 .cache
+.cache-main
+.cache-tests
 target
 metastore_db
 derby.log

--- a/schedoscope-core/pom.xml
+++ b/schedoscope-core/pom.xml
@@ -7,10 +7,9 @@
 	<name>Schedoscope Core</name>
 	<description>The Schedoscope Hadoop scheduler</description>
 
-
 	<properties>
-		<akka.version>2.3.6</akka.version>
-		<scala.version>2.10</scala.version>
+		<akka.version>2.3.14</akka.version>
+		<scala.version>2.11</scala.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -73,31 +72,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>ascii-table</groupId>
-			<artifactId>ascii-table</artifactId>
-			<version>1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.scopt</groupId>
-			<artifactId>scopt_2.10</artifactId>
-			<version>3.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>io.spray</groupId>
-			<artifactId>spray-client</artifactId>
-			<version>1.3.1</version>
-		</dependency>
-		<dependency>
-			<groupId>io.spray</groupId>
-			<artifactId>spray-json_2.10</artifactId>
-			<version>1.2.6</version>
-		</dependency>
-		<dependency>
-			<groupId>io.spray</groupId>
-			<artifactId>spray-routing</artifactId>
-			<version>1.3.1</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
@@ -118,13 +92,29 @@
 			<version>1.3.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-contrib_${scala.version}</artifactId>
-			<version>${akka.version}</version>
+			<artifactId>jline</artifactId>
+			<groupId>jline</groupId>
+			<version>0.9.94</version>
+		</dependency>
+		<dependency>
+			<groupId>ascii-table</groupId>
+			<artifactId>ascii-table</artifactId>
+			<version>1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-slf4j_${scala.version}</artifactId>
+			<version>${akka.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-contrib_${scala.version}</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
@@ -133,9 +123,39 @@
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
-			<artifactId>jline</artifactId>
-			<groupId>jline</groupId>
-			<version>0.9.94</version>
+			<groupId>io.spray</groupId>
+			<artifactId>spray-client_${scala.version}</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.spray</groupId>
+			<artifactId>spray-json_${scala.version}</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.spray</groupId>
+			<artifactId>spray-routing_${scala.version}</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.kamon</groupId>
+			<artifactId>kamon-core_${scala.version}</artifactId>
+			<version>0.5.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.kamon</groupId>
+			<artifactId>kamon-statsd_${scala.version}</artifactId>
+			<version>0.5.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.kamon</groupId>
+			<artifactId>kamon-akka_${scala.version}</artifactId>
+			<version>0.5.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.scopt</groupId>
+			<artifactId>scopt_${scala.version}</artifactId>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hive</groupId>
@@ -144,6 +164,10 @@
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-log4j12</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
@@ -157,12 +181,22 @@
 					<artifactId>slf4j-log4j12</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.oozie</groupId>
 			<artifactId>oozie-client</artifactId>
 			<version>${oozie.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.pig</groupId>
@@ -177,6 +211,10 @@
 					<artifactId>slf4j-log4j12</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -186,6 +224,10 @@
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-log4j12</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
@@ -198,7 +240,7 @@
 		<dependency>
 			<groupId>morphline-utils</groupId>
 			<artifactId>morphline-utils</artifactId>
-			<version>0.1.7</version>
+			<version>0.1.8</version>
 		</dependency>
 		<dependency>
 			<groupId>minioozie</groupId>
@@ -209,6 +251,10 @@
 				<exclusion>
 					<artifactId>jersey-server</artifactId>
 					<groupId>com.sun.jersey</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -227,7 +273,7 @@
 		<dependency>
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_${scala.version}</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -236,33 +282,23 @@
 			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-     		 <groupId>io.kamon</groupId>
-     		 <artifactId>kamon-core_2.10</artifactId>
-     		 <version>0.4.0</version>
-    	</dependency>		
-    	<dependency>
-     		 <groupId>io.kamon</groupId>
-     		 <artifactId>kamon-statsd_2.10</artifactId>
-     		 <version>0.4.0</version>
-    	</dependency>
-    	<dependency>
-     		 <groupId>io.kamon</groupId>
-     		 <artifactId>kamon-akka_2.10</artifactId>
-     		 <version>0.4.0</version>
-     		 
-    	</dependency>
-    	    	
 	</dependencies>
 
 	<build>
-		<sourceDirectory>src/main/scala</sourceDirectory>
-		<testSourceDirectory>src/test/scala</testSourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.3</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -271,7 +307,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.6</version>
+				<version>2.7</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
@@ -280,20 +316,13 @@
 				<!-- see http://davidb.github.com/scala-maven-plugin -->
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.2.2</version>
 				<executions>
 					<execution>
 						<goals>
 							<goal>compile</goal>
 							<goal>testCompile</goal>
 						</goals>
-						<configuration>
-							<args>
-								<arg>-make:transitive</arg>
-								<arg>-dependencyfile</arg>
-								<arg>${project.build.directory}/.scala_dependencies</arg>
-							</args>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -324,7 +353,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.7</version>
+				<version>2.19</version>
 				<configuration>
 					<skipTests>true</skipTests>
 				</configuration>

--- a/schedoscope-core/src/main/resources/reference.conf
+++ b/schedoscope-core/src/main/resources/reference.conf
@@ -726,7 +726,7 @@ akka {
         # for reasons of responsiveness.
         #
 
-        actions-manager-dispatcher {
+        transformation-manager-dispatcher {
             executor = "thread-pool-executor"
             type = PinnedDispatcher         
         }

--- a/schedoscope-core/src/main/scala/org/schedoscope/AskPattern.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/AskPattern.scala
@@ -16,23 +16,19 @@
 package org.schedoscope
 
 import java.util.concurrent.TimeUnit
-
-import scala.annotation.implicitNotFound
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-
-import org.schedoscope.scheduler.RootActor
-
 import akka.actor.ActorRef
 import akka.pattern.Patterns
 import akka.util.Timeout
+import org.schedoscope.scheduler.RootActor
 
 /**
- * Package object that contains commonly codified ask patterns for actors.
+ * Contains commonly codified ask patterns for actors.
  */
-package object scheduler {
+object AskPattern {
   implicit val executionContext: ExecutionContext = RootActor.settings.system.dispatchers.lookup("akka.actor.future-call-dispatcher")
 
   /**

--- a/schedoscope-core/src/main/scala/org/schedoscope/Settings.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/Settings.scala
@@ -21,6 +21,7 @@ import java.util.Calendar
 import java.util.concurrent.TimeUnit
 import scala.Array.canBuildFrom
 import scala.collection.mutable.HashMap
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.Duration
 import scala.collection.JavaConversions._
 import org.apache.hadoop.conf.Configuration
@@ -76,8 +77,8 @@ class SettingsImpl(val config: Config) extends Extension {
     }
   }
 
-  lazy val webserviceTimeOut: Duration =
-    Duration(config.getDuration("schedoscope.webservice.timeout", TimeUnit.MILLISECONDS),
+  lazy val webserviceTimeout =
+    Duration.create(config.getDuration("schedoscope.webservice.timeout", TimeUnit.MILLISECONDS),
       TimeUnit.MILLISECONDS)
 
   lazy val host = config.getString("schedoscope.webservice.host")

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/FieldLike.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/FieldLike.scala
@@ -40,7 +40,7 @@ abstract class FieldLike[T: Manifest] extends Named {
    */
   override def namingBase = assignedStructure match {
     case Some(s) => s.nameOf(this).getOrElse(t.runtimeClass.getSimpleName)
-    case None => t.runtimeClass.getSimpleName
+    case None    => t.runtimeClass.getSimpleName
   }
 }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/Named.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/Named.scala
@@ -19,7 +19,7 @@ package org.schedoscope.dsl
  * A trait for entities that have a name, e.g., views, fields, and parameters.
  */
 trait Named {
-  
+
   /**
    * The base name of the Named entity.
    */
@@ -35,7 +35,7 @@ trait Named {
  * Helpers for Named entities
  */
 object Named {
-  
+
   /**
    * converts camel case to lower_case / underscore format.
    */

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/Structure.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/Structure.scala
@@ -30,6 +30,9 @@ abstract class Structure extends StructureDsl with Named {
     f.assignTo(this)
   }
 
+  /**
+   * Return all fields in weight order.
+   */
   def fields = {
     val fieldsWithWeightsAndPosition = ListBuffer[(Long, Int, Field[_])]()
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -15,6 +15,8 @@
  */
 package org.schedoscope.dsl
 
+import scala.language.existentials
+import scala.language.implicitConversions
 import scala.Array.canBuildFrom
 import scala.collection.JavaConversions.asScalaBuffer
 import scala.collection.JavaConversions.seqAsJavaList
@@ -352,7 +354,7 @@ object View {
       var passedValueForParameter: TypedAny = null
 
       for (parameterValue <- parameterValuesPassed; if passedValueForParameter == null) {
-        if (constructorParameterType.isAssignableFrom(parameterValue.t.erasure)) {
+        if (constructorParameterType.isAssignableFrom(parameterValue.t.runtimeClass)) {
           passedValueForParameter = parameterValue
         }
       }

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -53,7 +53,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
       nWithoutPartitioningSuffix + "_" + suffixPartitionParameters.map { p => p.v.get }.mkString("_").toLowerCase()
 
   /**
-   * The package and view class prefix of the URL syntax representing the present view    
+   * The package and view class prefix of the URL syntax representing the present view
    */
   def urlPathPrefix = s"${lowerCasePackageName}/${namingBase.replaceAll("[^a-zA-Z0-9]", "")}"
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -57,7 +57,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   /**
    * The URL path syntax identifying the present view.
    */
-  def urlPath = s"${urlPathPrefix}/${partitionValues.mkString("/")}"
+  def urlPath = s"${urlPathPrefix}/${partitionValues(false).mkString("/")}"
 
   /**
    * The view's environment.
@@ -162,7 +162,11 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   /**
    * Returns a list of partition values in order the parameter weights. Such lists are necessary for communicating with the metastore.
    */
-  def partitionValues = partitionParameters.map(p => p.v.getOrElse("").toString).toList
+  def partitionValues(ignoreSuffixPartitions: Boolean = true) =
+    (if (ignoreSuffixPartitions)
+      partitionParameters
+    else
+      parameters).map(p => p.v.getOrElse("").toString).toList
 
   private val suffixPartitions = new HashSet[Parameter[_]]()
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -52,6 +52,9 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
     else
       nWithoutPartitioningSuffix + "_" + suffixPartitionParameters.map { p => p.v.get }.mkString("_").toLowerCase()
 
+  /**
+   * The package and view class prefix of the URL syntax representing the present view    
+   */
   def urlPathPrefix = s"${lowerCasePackageName}/${namingBase.replaceAll("[^a-zA-Z0-9]", "")}"
 
   /**

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/ViewDsl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/ViewDsl.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.schedoscope.dsl
+
 import org.schedoscope.dsl.storageformats._
 import org.schedoscope.dsl.transformations.Transformation
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.schedoscope.dsl.storageformats
+
 import org.schedoscope.dsl._
 
 /**
@@ -105,4 +106,4 @@ case class Redis(host: String, port: Long = 9393, password: String = "", keys: S
 /**
  *  Does not store anything, this table is just for side-effects
  */
-case class NullStorage extends ExternalStorageFormat
+case class NullStorage() extends ExternalStorageFormat

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/MorphlineTransformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/MorphlineTransformation.scala
@@ -31,11 +31,11 @@ import org.schedoscope.dsl.FieldLike
  *
  */
 case class MorphlineTransformation(definition: String = "",
-  imports: Seq[String] = List(),
-  sampling: Int = 100,
-  anonymize: Seq[Named] = List(),
-  fields: Seq[Named] = List(),
-  fieldMapping: Map[FieldLike[_], FieldLike[_]] = Map()) extends ExternalTransformation {
+                                   imports: Seq[String] = List(),
+                                   sampling: Int = 100,
+                                   anonymize: Seq[Named] = List(),
+                                   fields: Seq[Named] = List(),
+                                   fieldMapping: Map[FieldLike[_], FieldLike[_]] = Map()) extends ExternalTransformation {
   def name() = "morphline"
 
   override def versionDigest = Version.digest(resourceHashes :+ definition)

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/DateParameterization.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/DateParameterization.scala
@@ -16,12 +16,9 @@
 package org.schedoscope.dsl.views
 
 import java.util.Calendar
-
 import org.schedoscope.dsl.Parameter
 import org.schedoscope.dsl.Parameter.p
-
 import org.schedoscope.Settings
-
 import scala.collection.mutable.ListBuffer
 
 object DateParameterizationUtils {
@@ -66,7 +63,7 @@ object DateParameterizationUtils {
   def prevDay(year: Parameter[String], month: Parameter[String], day: Parameter[String]): Option[(String, String, String)] = {
     prevDay(parametersToDay(year, month, day)) match {
       case Some(previousDay) => Some(dayToStrings(previousDay))
-      case None => None
+      case None              => None
     }
   }
 
@@ -149,7 +146,7 @@ object DateParameterizationUtils {
   def prevMonth(year: Parameter[String], month: Parameter[String]): Option[(String, String)] = {
     prevMonth(parametersToDay(year, month, p("01"))) match {
       case Some(previousDay) => Some((dayToStrings(previousDay)._1, dayToStrings(previousDay)._2))
-      case None => None
+      case None              => None
     }
   }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/JobMetadata.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/JobMetadata.scala
@@ -16,7 +16,6 @@
 package org.schedoscope.dsl.views
 
 import java.util.Date
-
 import org.schedoscope.dsl.ViewDsl
 
 trait JobMetadata extends ViewDsl {

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/ViewUrlParser.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/views/ViewUrlParser.scala
@@ -16,9 +16,7 @@
 package org.schedoscope.dsl.views
 
 import java.net.URLDecoder
-
 import scala.Array.canBuildFrom
-
 import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.dsl.View
 import org.schedoscope.dsl.View.TypedAny
@@ -57,16 +55,16 @@ object ViewUrlParser {
     .replaceAllLiterally("\\-", "-")
 
   def typeBasicParameter(parameter: String) = parameter match {
-    case NullValue() => List(null)
-    case BooleanValue(b, _, _) => List(t(p(b.toBoolean)))
-    case IntValue(d) => List(t(p(d.toInt)))
-    case LongValue(d) => List(t(p(d.toLong)))
-    case ByteValue(d) => List(t(p(d.toByte)))
-    case FloatValue(f) => List(t(p(f.toFloat)))
-    case DoubleValue(f) => List(t(p(f.toDouble)))
-    case MonthlyParameterizationValue(y, m) => List(t(p(y)), t(p(m)))
+    case NullValue()                         => List(null)
+    case BooleanValue(b, _, _)               => List(t(p(b.toBoolean)))
+    case IntValue(d)                         => List(t(p(d.toInt)))
+    case LongValue(d)                        => List(t(p(d.toLong)))
+    case ByteValue(d)                        => List(t(p(d.toByte)))
+    case FloatValue(f)                       => List(t(p(f.toFloat)))
+    case DoubleValue(f)                      => List(t(p(f.toDouble)))
+    case MonthlyParameterizationValue(y, m)  => List(t(p(y)), t(p(m)))
     case DailyParameterizationValue(y, m, d) => List(t(p(y)), t(p(m)), t(p(d)))
-    case aStringValue => List(t(p(unquote(aStringValue))))
+    case aStringValue                        => List(t(p(unquote(aStringValue))))
   }
 
   def typeMonthlyRangeParameter(earlierYear: String, earlierMonth: String, laterYear: String, laterMonth: String): List[List[TypedAny]] =

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ActionsManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ActionsManagerActor.scala
@@ -20,9 +20,7 @@ import scala.collection.JavaConversions.asScalaSet
 import scala.collection.mutable.HashMap
 import scala.concurrent.duration.DurationInt
 import scala.util.Random
-
 import org.apache.hadoop.conf.Configuration
-
 import org.schedoscope.Settings
 import org.schedoscope.scheduler.driver.DriverException
 import org.schedoscope.dsl.transformations.Transformation
@@ -116,7 +114,7 @@ class ActionsManagerActor() extends Actor {
   override val supervisorStrategy =
     OneForOneStrategy(maxNrOfRetries = -1) {
       case _: DriverException => Restart
-      case _: Throwable => Escalate
+      case _: Throwable       => Escalate
     }
 
   /**
@@ -135,9 +133,9 @@ class ActionsManagerActor() extends Actor {
 
     case asr: ActionStatusResponse[_] => driverStates.put(asr.actor.path.toStringWithoutAddress, asr)
 
-    case GetActions() => sender ! ActionStatusListResponse(driverStates.values.toList)
+    case GetActions()                 => sender ! ActionStatusListResponse(driverStates.values.toList)
 
-    case GetQueues() => sender ! QueueStatusListResponse(actionQueueStatus)
+    case GetQueues()                  => sender ! QueueStatusListResponse(actionQueueStatus)
 
     case PollCommand(transformationType) => {
       val queueForType = queues.get(queueNameForTransformationType(transformationType)).get
@@ -168,11 +166,11 @@ class ActionsManagerActor() extends Actor {
       }
     }
 
-    case viewAction: View => self ! CommandWithSender(viewAction.transformation().forView(viewAction), sender)
+    case viewAction: View                                         => self ! CommandWithSender(viewAction.transformation().forView(viewAction), sender)
 
     case filesystemTransformationAction: FilesystemTransformation => self ! CommandWithSender(filesystemTransformationAction, sender)
 
-    case deployAction: Deploy => self ! CommandWithSender(deployAction, sender)
+    case deployAction: Deploy                                     => self ! CommandWithSender(deployAction, sender)
   })
 }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
@@ -15,6 +15,7 @@
  */
 package org.schedoscope.scheduler
 
+import scala.language.postfixOps
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import org.schedoscope.DriverSettings

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
@@ -142,7 +142,7 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
         }
 
         case failure: DriverRunFailed[T] => {
-          log.error(s"DRIVER ACTOR: Driver run for handle=${runHandle} failed. ${failure.reason}, cause ${failure.cause}")
+          log.error(s"DRIVER ACTOR: Driver run for handle=${runHandle} failed. ${failure.reason}, cause ${failure.cause}, trace ${if (failure.cause != null) failure.cause.getStackTrace else "no trace available"}")
 
           try {
             driver.driverRunCompleted(runHandle)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
@@ -54,10 +54,10 @@ import org.schedoscope.scheduler.driver.DriverException
 /**
  * A driver actor manages the executions of transformations using hive, oozie etc. The actual
  * execution is done using a driver trait implementation. The driver actor code itself is transformation
- * type agnostic
+ * type agnostic. Driver actors poll the transformation tasks they execute from the transformation manager actor
  *
  */
-class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: DriverSettings, driverConstructor: (DriverSettings) => Driver[T], pingDuration: FiniteDuration) extends Actor {
+class DriverActor[T <: Transformation](transformationManagerActor: ActorRef, ds: DriverSettings, driverConstructor: (DriverSettings) => Driver[T], pingDuration: FiniteDuration) extends Actor {
   import context._
   val log = Logging(system, this)
 
@@ -74,11 +74,11 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
   }
 
   /**
-   * If the driver actor is to be restarted by the actions manager actor, the currently running action is reenqueued so it does not get lost.
+   * If the driver actor is being restarted by the transformation manager actor, the currently running action is reenqueued so it does not get lost.
    */
   override def preRestart(reason: Throwable, message: Option[Any]) {
     if (runningCommand.isDefined)
-      actionsManagerActor ! runningCommand.get
+      transformationManagerActor ! runningCommand.get
   }
 
   /**
@@ -96,7 +96,7 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
     case CommandWithSender(command, sender) => toRunning(CommandWithSender(command, sender))
 
     case "tick" => {
-      actionsManagerActor ! PollCommand(driver.transformationName)
+      transformationManagerActor ! PollCommand(driver.transformationName)
       tick()
     }
   }
@@ -107,13 +107,13 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
    * @param originalSender reference to the viewActor that requested the transformation (for sending back the result)
    */
   def running(runHandle: DriverRunHandle[T], originalSender: ActorRef): Receive = LoggingReceive {
-    case KillAction() => {
+    case KillCommand() => {
       driver.killRun(runHandle)
       toReceive()
     }
     // If getting a command while being busy, reschedule it by sending it to the actionsmanager
     // Should this ever happen?
-    case c: CommandWithSender => actionsManagerActor ! c
+    case c: CommandWithSender => transformationManagerActor ! c
 
     // check all 10 seconds the state of the current running driver
     case "tick" => try {
@@ -130,13 +130,13 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
 
             case t: Throwable => {
               log.error(s"DRIVER ACTOR: Driver run for handle=${runHandle} failed because completion handler threw exception ${t}")
-              originalSender ! ActionFailure(runHandle, DriverRunFailed[T](driver, "Completition handler failed", t))
+              originalSender ! TransformationFailure(runHandle, DriverRunFailed[T](driver, "Completition handler failed", t))
               toReceive()
               tick()
             }
           }
 
-          originalSender ! ActionSuccess(runHandle, success)
+          originalSender ! TransformationSuccess(runHandle, success)
           toReceive()
           tick()
         }
@@ -153,7 +153,7 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
             }
           }
 
-          originalSender ! ActionFailure(runHandle, failure)
+          originalSender ! TransformationFailure(runHandle, failure)
           toReceive()
           tick()
         }
@@ -195,12 +195,12 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
     runningCommand = Some(commandToRun)
 
     try {
-      if (commandToRun.command.isInstanceOf[Deploy]) {
+      if (commandToRun.command.isInstanceOf[DeployCommand]) {
 
         logStateInfo("deploy", s"DRIVER ACTOR: Running Deploy command")
 
         driver.deployAll(ds)
-        commandToRun.sender ! DeployActionSuccess()
+        commandToRun.sender ! DeployCommandSuccess()
 
         logStateInfo("idle", "DRIVER ACTOR: becoming idle")
 
@@ -227,7 +227,7 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
   }
 
   def logStateInfo(state: String, message: String, runHandle: DriverRunHandle[T] = null, runState: DriverRunState[T] = null) {
-    actionsManagerActor ! ActionStatusResponse(state, self, driver, runHandle, runState)
+    transformationManagerActor ! TransformationStatusResponse(state, self, driver, runHandle, runState)
     log.info(message)
   }
 }
@@ -236,37 +236,37 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
  * Factory methods for driver actors.
  */
 object DriverActor {
-  def props(driverName: String, actionsRouter: ActorRef) = {
+  def props(driverName: String, transformationManager: ActorRef) = {
     val ds = Settings().getDriverSettings(driverName)
 
     driverName match {
       case "hive" => Props(
         classOf[DriverActor[HiveTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => HiveDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => HiveDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "mapreduce" => Props(
         classOf[DriverActor[MapreduceTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => MapreduceDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => MapreduceDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "pig" => Props(
         classOf[DriverActor[PigTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => PigDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => PigDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "filesystem" => Props(
         classOf[DriverActor[FilesystemTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => FileSystemDriver(ds), 100 milliseconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => FileSystemDriver(ds), 100 milliseconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "oozie" => Props(
         classOf[DriverActor[OozieTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => OozieDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => OozieDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "morphline" => Props(
         classOf[DriverActor[MorphlineTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => MorphlineDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => MorphlineDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case "shell" => Props(
         classOf[DriverActor[ShellTransformation]],
-        actionsRouter, ds, (ds: DriverSettings) => ShellDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
+        transformationManager, ds, (ds: DriverSettings) => ShellDriver(ds), 5 seconds).withDispatcher("akka.actor.driver-dispatcher")
 
       case _ => throw DriverException(s"Driver for ${driverName} not found")
     }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/DriverActor.scala
@@ -160,12 +160,12 @@ class DriverActor[T <: Transformation](actionsManagerActor: ActorRef, ds: Driver
       }
     } catch {
       case exception: DriverException => {
-        log.error(s"DRIVER ACTOR: Driver exception caught by driver actor in running state, rethrowing: ${exception.message}, cause ${exception.cause}")
+        log.error(s"DRIVER ACTOR: Driver exception caught by driver actor in running state, rethrowing: ${exception.message}, cause ${exception.cause}, trace ${exception.getStackTrace}")
         throw exception
       }
 
       case t: Throwable => {
-        log.error(s"DRIVER ACTOR: Unexpected exception caught by driver actor in running state, rethrowing: ${t.getMessage()}, cause ${t.getCause()}")
+        log.error(s"DRIVER ACTOR: Unexpected exception caught by driver actor in running state, rethrowing: ${t.getMessage()}, cause ${t.getCause()}, trace ${t.getStackTrace}")
         throw t
       }
     }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/MetadataLoggerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/MetadataLoggerActor.scala
@@ -24,7 +24,6 @@ import akka.event.Logging
 import akka.event.LoggingReceive
 import akka.routing.SmallestMailboxRoutingLogic
 import akka.routing.Router
-import akka.routing.RoundRobinRouter
 import org.schedoscope.scheduler.messages._
 
 /**

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/SchemaActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/SchemaActor.scala
@@ -25,7 +25,6 @@ import akka.event.Logging
 import akka.event.LoggingReceive
 import akka.routing.SmallestMailboxRoutingLogic
 import akka.routing.Router
-import akka.routing.RoundRobinRouter
 
 /**
  * Schema actors are responsible for creating tables and partitions in the metastore.

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/TransformationManagerActor.scala
@@ -15,18 +15,25 @@
  */
 package org.schedoscope.scheduler
 
-import scala.annotation.migration
 import scala.collection.JavaConversions.asScalaSet
 import scala.collection.mutable.HashMap
-import scala.concurrent.duration.DurationInt
 import scala.util.Random
+
 import org.apache.hadoop.conf.Configuration
 import org.schedoscope.Settings
-import org.schedoscope.scheduler.driver.DriverException
-import org.schedoscope.dsl.transformations.Transformation
 import org.schedoscope.dsl.View
 import org.schedoscope.dsl.transformations.FilesystemTransformation
-import org.schedoscope.scheduler.messages._
+import org.schedoscope.dsl.transformations.Transformation
+import org.schedoscope.scheduler.driver.DriverException
+import org.schedoscope.scheduler.messages.CommandWithSender
+import org.schedoscope.scheduler.messages.DeployCommand
+import org.schedoscope.scheduler.messages.GetTransformations
+import org.schedoscope.scheduler.messages.GetQueues
+import org.schedoscope.scheduler.messages.PollCommand
+import org.schedoscope.scheduler.messages.QueueStatusListResponse
+import org.schedoscope.scheduler.messages.TransformationStatusListResponse
+import org.schedoscope.scheduler.messages.TransformationStatusResponse
+
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.OneForOneStrategy
@@ -38,17 +45,17 @@ import akka.event.Logging
 import akka.event.LoggingReceive
 
 /**
- * The actions manager actor queues transformation requests ("actions") it receives from view actors by
- * transformation type. Idle driver actors poll the actions manager for new actions to perform.
+ * The transformation manager actor queues transformation requests it receives from view actors by
+ * transformation type. Idle driver actors poll the transformation manager for new transformations to perform.
  *
  */
-class ActionsManagerActor() extends Actor {
+class TransformationManagerActor() extends Actor {
   import context._
 
-  val log = Logging(system, ActionsManagerActor.this)
+  val log = Logging(system, TransformationManagerActor.this)
   val settings = Settings.get(system)
 
-  val driverStates = HashMap[String, ActionStatusResponse[_]]()
+  val driverStates = HashMap[String, TransformationStatusResponse[_]]()
 
   val availableTransformations = settings.availableTransformations.keySet()
 
@@ -71,7 +78,7 @@ class ActionsManagerActor() extends Actor {
   def hash(s: String) = Math.max(0,
     s.hashCode().abs % filesystemConcurrency)
 
-  def queueNameForTransformationAction(t: Transformation, s: ActorRef) =
+  def queueNameForTransformation(t: Transformation, s: ActorRef) =
     if (t.name != "filesystem")
       t.name
     else {
@@ -103,7 +110,7 @@ class ActionsManagerActor() extends Actor {
       }
     }
 
-  private def actionQueueStatus() = {
+  private def transformationQueueStatus() = {
     queues.map(q => (q._1, q._2.map(c => c.command).toList))
   }
 
@@ -131,11 +138,11 @@ class ActionsManagerActor() extends Actor {
    */
   def receive = LoggingReceive({
 
-    case asr: ActionStatusResponse[_] => driverStates.put(asr.actor.path.toStringWithoutAddress, asr)
+    case asr: TransformationStatusResponse[_] => driverStates.put(asr.actor.path.toStringWithoutAddress, asr)
 
-    case GetActions()                 => sender ! ActionStatusListResponse(driverStates.values.toList)
+    case GetTransformations()                 => sender ! TransformationStatusListResponse(driverStates.values.toList)
 
-    case GetQueues()                  => sender ! QueueStatusListResponse(actionQueueStatus)
+    case GetQueues()                          => sender ! QueueStatusListResponse(transformationQueueStatus)
 
     case PollCommand(transformationType) => {
       val queueForType = queues.get(queueNameForTransformationType(transformationType)).get
@@ -147,36 +154,36 @@ class ActionsManagerActor() extends Actor {
 
         if (cmd.command.isInstanceOf[Transformation]) {
           val transformation = cmd.command.asInstanceOf[Transformation]
-          log.info(s"ACTIONMANAGER DEQUEUE: Dequeued ${transformationType} transformation ${transformation}${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queueForType.size}")
+          log.info(s"TRANSFORMATIONMANAGER DEQUEUE: Dequeued ${transformationType} transformation ${transformation}${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queueForType.size}")
         } else
-          log.info("ACTIONMANAGER DEQUEUE: Dequeued deploy action")
+          log.info("TRANSFORMATIONMANAGER DEQUEUE: Dequeued deploy action")
       }
     }
 
-    case actionCommand: CommandWithSender => {
-      if (actionCommand.command.isInstanceOf[Transformation]) {
-        val transformation = actionCommand.command.asInstanceOf[Transformation]
-        val queueName = queueNameForTransformationAction(transformation, actionCommand.sender)
+    case commandToExecute: CommandWithSender => {
+      if (commandToExecute.command.isInstanceOf[Transformation]) {
+        val transformation = commandToExecute.command.asInstanceOf[Transformation]
+        val queueName = queueNameForTransformation(transformation, commandToExecute.sender)
 
-        queues.get(queueName).get.enqueue(actionCommand)
-        log.info(s"ACTIONMANAGER ENQUEUE: Enqueued ${queueName} transformation ${transformation}${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queues.get(queueName).get.size}")
+        queues.get(queueName).get.enqueue(commandToExecute)
+        log.info(s"TRANSFORMATIONMANAGER ENQUEUE: Enqueued ${queueName} transformation ${transformation}${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queues.get(queueName).get.size}")
       } else {
-        queues.values.foreach { _.enqueue(actionCommand) }
-        log.info("ACTIONMANAGER ENQUEUE: Enqueued deploy action")
+        queues.values.foreach { _.enqueue(commandToExecute) }
+        log.info("TRANSFORMATIONMANAGER ENQUEUE: Enqueued deploy action")
       }
     }
 
-    case viewAction: View                                         => self ! CommandWithSender(viewAction.transformation().forView(viewAction), sender)
+    case viewToTransform: View                              => self ! CommandWithSender(viewToTransform.transformation().forView(viewToTransform), sender)
 
-    case filesystemTransformationAction: FilesystemTransformation => self ! CommandWithSender(filesystemTransformationAction, sender)
+    case filesystemTransformation: FilesystemTransformation => self ! CommandWithSender(filesystemTransformation, sender)
 
-    case deployAction: Deploy                                     => self ! CommandWithSender(deployAction, sender)
+    case deploy: DeployCommand                              => self ! CommandWithSender(deploy, sender)
   })
 }
 
 /**
  * Factory for the actions manager actor.
  */
-object ActionsManagerActor {
-  def props(conf: Configuration) = Props[ActionsManagerActor].withDispatcher("akka.actor.actions-manager-dispatcher")
+object TransformationManagerActor {
+  def props(conf: Configuration) = Props[TransformationManagerActor].withDispatcher("akka.actor.transformation-manager-dispatcher")
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewActor.scala
@@ -131,7 +131,7 @@ class ViewActor(view: View, settings: SettingsImpl, viewManagerActor: ActorRef, 
   // transitions: materialized,retrying
   def transforming(retries: Int, materializationMode: MaterializeViewMode): Receive = LoggingReceive({
 
-    case _: ActionSuccess[_] => {
+    case _: TransformationSuccess[_] => {
       log.info("SUCCESS")
 
       setVersion(view)
@@ -157,7 +157,7 @@ class ViewActor(view: View, settings: SettingsImpl, viewManagerActor: ActorRef, 
       }
     }
 
-    case _: ActionFailure[_]               => toRetrying(retries, materializationMode)
+    case _: TransformationFailure[_]       => toRetrying(retries, materializationMode)
 
     case MaterializeView(mode)             => listenersWaitingForMaterialize.add(sender)
 
@@ -362,7 +362,7 @@ class ViewActor(view: View, settings: SettingsImpl, viewManagerActor: ActorRef, 
     unbecomeBecome(transforming(retries, mode))
 
     if (mode == RESET_TRANSFORMATION_CHECKSUMS_AND_TIMESTAMPS) {
-      self ! ActionSuccess[NoOp](null, null)
+      self ! TransformationSuccess[NoOp](null, null)
       log.info(s"VIEWACTOR CHECKSUM AND TIMESTAMP RESET ===> Faking successful transformation action result")
     }
   }
@@ -415,7 +415,6 @@ class ViewActor(view: View, settings: SettingsImpl, viewManagerActor: ActorRef, 
   }
 
   def hasVersionMismatch(view: View) = view.transformation().versionDigest() != versionChecksum
-
 
   def logTransformationTimestamp(view: View) = {
     lastTransformationTimestamp = new Date().getTime()

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewActor.scala
@@ -281,7 +281,10 @@ class ViewActor(view: View, settings: SettingsImpl, viewManagerActor: ActorRef, 
         try {
           ViewManagerActor.actorForView(d) ! MaterializeView(mode)
         } catch {
-          case _: Throwable => queryActor(viewManagerActor, d, settings.viewManagerResponseTimeout).asInstanceOf[ActorRef] ! MaterializeView(mode)
+          case t: Throwable => {
+            log.warning(s"Failed to sende materialize message to view actor for dependency. Exception: ${t.getStackTrace}. Asking view manager actor to create one.")
+            queryActor(viewManagerActor, d, settings.viewManagerResponseTimeout).asInstanceOf[ActorRef] ! MaterializeView(mode)
+          }
         }
       }
     }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/ViewManagerActor.scala
@@ -160,9 +160,9 @@ class ViewManagerActor(settings: SettingsImpl, actionsManagerActor: ActorRef, sc
     }
 
     if (dependencies)
-      allViews.map { case (view, _, _) => actorsForViews.get(view) }.distinct
+      allViews.map { case (view, _, _) => actorsForViews.get(view).get }.distinct
     else
-      allViews.filter { case (_, _, depth) => depth == 0 }.map { case (view, _, _) => actorsForViews.get(view) }.distinct
+      allViews.filter { case (_, _, depth) => depth == 0 }.map { case (view, _, _) => actorsForViews.get(view).get }.distinct
   }
 }
 
@@ -175,9 +175,6 @@ object ViewManagerActor {
   def props(settings: SettingsImpl, actionsManagerActor: ActorRef, schemaActor: ActorRef, metadataLoggerActor: ActorRef): Props = Props(classOf[ViewManagerActor], settings: SettingsImpl, actionsManagerActor, schemaActor, metadataLoggerActor).withDispatcher("akka.actor.view-manager-dispatcher")
 
   def actorNameForView(v: View) = v.urlPath.replaceAll("/", ":")
-
-  def viewForActor(a: ActorRef) =
-    View.viewsFromUrl(RootActor.settings.env, a.path.name.replaceAll(":", "/"), RootActor.settings.viewAugmentor).head
 
   def actorForView(v: View) =
     system.actorSelection(RootActor.viewManagerActor.path.child(actorNameForView(v)))

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
@@ -28,7 +28,7 @@ object CliFormat { // FIXME: a more generic parsing would be cool...
   def serialize(o: Any): String = {
     val sb = new StringBuilder()
     o match {
-      case as: ActionStatusList => {
+      case as: TransformationStatusList => {
         if (as.actions.size > 0) {
           val header = Array("ACTOR", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
           val running = as.actions.map(p => {
@@ -98,7 +98,7 @@ object SchedoscopeClientControl extends App {
 
 class SchedoscopeControl(schedoscope: SchedoscopeInterface) {
   object Action extends Enumeration {
-    val VIEWS, ACTIONS, QUEUES, MATERIALIZE, COMMANDS, INVALIDATE, NEWDATA, SHUTDOWN = Value
+    val VIEWS, TRANSFORMATIONS, QUEUES, MATERIALIZE, COMMANDS, INVALIDATE, NEWDATA, SHUTDOWN = Value
   }
   import Action._
 
@@ -116,9 +116,9 @@ class SchedoscopeControl(schedoscope: SchedoscopeInterface) {
       opt[Unit]('d', "dependencies") action { (_, c) => c.copy(dependencies = Some(true)) } optional () text ("include dependencies"),
       opt[Unit]('o', "overview") action { (_, c) => c.copy(overview = Some(true)) } optional () text ("show only overview, skip individual views"))
 
-    cmd("actions") action { (_, c) => c.copy(action = Some(ACTIONS)) } text ("list status of action actors") children (
-      opt[String]('s', "status") action { (x, c) => c.copy(status = Some(x)) } optional () valueName ("<status>") text ("filter actions by their status (e.g. 'queued, running, idle')"),
-      opt[String]('f', "filter") action { (x, c) => c.copy(filter = Some(x)) } optional () valueName ("<regex>") text ("regular expression to filter action display (e.g. '.*hive-1.*'). "))
+    cmd("transformations") action { (_, c) => c.copy(action = Some(TRANSFORMATIONS)) } text ("list status of running transformations") children (
+      opt[String]('s', "status") action { (x, c) => c.copy(status = Some(x)) } optional () valueName ("<status>") text ("filter transformations by their status (e.g. 'queued, running, idle')"),
+      opt[String]('f', "filter") action { (x, c) => c.copy(filter = Some(x)) } optional () valueName ("<regex>") text ("regular expression to filter transformation display (e.g. '.*hive-1.*'). "))
 
     cmd("queues") action { (_, c) => c.copy(action = Some(QUEUES)) } text ("list queued actions") children (
       opt[String]('t', "typ") action { (x, c) => c.copy(typ = Some(x)) } optional () valueName ("<type>") text ("filter queued actions by their type (e.g. 'oozie', 'filesystem', ...)"),
@@ -160,8 +160,8 @@ class SchedoscopeControl(schedoscope: SchedoscopeInterface) {
         println("Starting " + config.action.get.toString + " ...")
         try {
           val res = config.action.get match {
-            case ACTIONS => {
-              schedoscope.actions(config.status, config.filter)
+            case TRANSFORMATIONS => {
+              schedoscope.transformations(config.status, config.filter)
             }
             case QUEUES => {
               schedoscope.queues(config.typ, config.filter)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
@@ -30,7 +30,7 @@ object CliFormat { // FIXME: a more generic parsing would be cool...
     o match {
       case as: TransformationStatusList => {
         if (as.actions.size > 0) {
-          val header = Array("TRANSFORMER", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
+          val header = Array("TRANSFORMATION DRIVER", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
           val running = as.actions.map(p => {
             val (s, d, t): (String, String, String) =
               if (p.runStatus.isDefined) {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
@@ -30,7 +30,7 @@ object CliFormat { // FIXME: a more generic parsing would be cool...
     o match {
       case as: TransformationStatusList => {
         if (as.actions.size > 0) {
-          val header = Array("ACTOR", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
+          val header = Array("TRANSFORMER", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
           val running = as.actions.map(p => {
             val (s, d, t): (String, String, String) =
               if (p.runStatus.isDefined) {
@@ -116,7 +116,7 @@ class SchedoscopeControl(schedoscope: SchedoscopeInterface) {
       opt[Unit]('d', "dependencies") action { (_, c) => c.copy(dependencies = Some(true)) } optional () text ("include dependencies"),
       opt[Unit]('o', "overview") action { (_, c) => c.copy(overview = Some(true)) } optional () text ("show only overview, skip individual views"))
 
-    cmd("transformations") action { (_, c) => c.copy(action = Some(TRANSFORMATIONS)) } text ("list status of running transformations") children (
+    cmd("transformations") action { (_, c) => c.copy(action = Some(TRANSFORMATIONS)) } text ("show transformation status") children (
       opt[String]('s', "status") action { (x, c) => c.copy(status = Some(x)) } optional () valueName ("<status>") text ("filter transformations by their status (e.g. 'queued, running, idle')"),
       opt[String]('f', "filter") action { (x, c) => c.copy(filter = Some(x)) } optional () valueName ("<regex>") text ("regular expression to filter transformation display (e.g. '.*hive-1.*'). "))
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeControl.scala
@@ -29,9 +29,9 @@ object CliFormat { // FIXME: a more generic parsing would be cool...
     val sb = new StringBuilder()
     o match {
       case as: TransformationStatusList => {
-        if (as.actions.size > 0) {
+        if (as.transformations.size > 0) {
           val header = Array("TRANSFORMATION DRIVER", "STATUS", "STARTED", "DESC", "TARGET_VIEW", "PROPS")
-          val running = as.actions.map(p => {
+          val running = as.transformations.map(p => {
             val (s, d, t): (String, String, String) =
               if (p.runStatus.isDefined) {
                 (p.runStatus.get.started, p.runStatus.get.description, p.runStatus.get.targetView)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeDaemon.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeDaemon.scala
@@ -17,7 +17,6 @@ package org.schedoscope.scheduler.api
 
 import org.apache.commons.daemon.Daemon
 import org.apache.commons.daemon.DaemonContext
-
 import org.schedoscope.scheduler.api.SchedoscopeRestService.Config
 
 trait ApplicationLifecycle {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeInterface.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeInterface.scala
@@ -29,7 +29,7 @@ trait SchedoscopeInterface {
 
   def views(viewUrlPath: Option[String], status: Option[String], filter: Option[String], dependencies: Option[Boolean], overview: Option[Boolean]): ViewStatusList
 
-  def actions(status: Option[String], filter: Option[String]): ActionStatusList
+  def transformations(status: Option[String], filter: Option[String]): TransformationStatusList
 
   def queues(typ: Option[String], filter: Option[String]): QueueStatusList
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
@@ -30,7 +30,7 @@ import spray.json.JsonFormat
 case class SchedoscopeCommand(id: String, start: String, parts: List[Future[_]])
 case class SchedoscopeCommandStatus(id: String, start: String, end: Option[String], status: Map[String, Int])
 case class TransformationStatus(actor: String, typ: String, status: String, runStatus: Option[RunStatus], properties: Option[Map[String, String]])
-case class TransformationStatusList(overview: Map[String, Int], actions: List[TransformationStatus])
+case class TransformationStatusList(overview: Map[String, Int], transformations: List[TransformationStatus])
 case class ViewStatus(view: String, status: String, properties: Option[Map[String, String]], dependencies: Option[List[ViewStatus]])
 case class ViewStatusList(overview: Map[String, Int], views: List[ViewStatus])
 case class QueueStatusList(overview: Map[String, Int], queues: Map[String, List[RunStatus]])

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
@@ -16,7 +16,6 @@
 package org.schedoscope.scheduler.api
 
 import scala.concurrent.Future
-
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
 import org.schedoscope.dsl.transformations.Transformation
@@ -25,7 +24,6 @@ import org.schedoscope.scheduler.driver.DriverRunFailed
 import org.schedoscope.scheduler.driver.DriverRunOngoing
 import org.schedoscope.scheduler.driver.DriverRunState
 import org.schedoscope.scheduler.driver.DriverRunSucceeded
-
 import spray.json.DefaultJsonProtocol
 import spray.json.JsonFormat
 
@@ -84,8 +82,8 @@ object SchedoscopeJsonProtocol extends DefaultJsonProtocol {
     if (a.driverRunStatus != null) {
       a.driverRunStatus.asInstanceOf[DriverRunState[Any with Transformation]] match {
         case s: DriverRunSucceeded[_] => { comment = getOrElse(s.comment, "no-comment"); status = "succeeded" }
-        case f: DriverRunFailed[_] => { comment = getOrElse(f.reason, "no-reason"); status = "failed" }
-        case o: DriverRunOngoing[_] => { drh = o.runHandle }
+        case f: DriverRunFailed[_]    => { comment = getOrElse(f.reason, "no-reason"); status = "failed" }
+        case o: DriverRunOngoing[_]   => { drh = o.runHandle }
       }
     }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeJsonProtocol.scala
@@ -29,8 +29,8 @@ import spray.json.JsonFormat
 
 case class SchedoscopeCommand(id: String, start: String, parts: List[Future[_]])
 case class SchedoscopeCommandStatus(id: String, start: String, end: Option[String], status: Map[String, Int])
-case class ActionStatus(actor: String, typ: String, status: String, runStatus: Option[RunStatus], properties: Option[Map[String, String]])
-case class ActionStatusList(overview: Map[String, Int], actions: List[ActionStatus])
+case class TransformationStatus(actor: String, typ: String, status: String, runStatus: Option[RunStatus], properties: Option[Map[String, String]])
+case class TransformationStatusList(overview: Map[String, Int], actions: List[TransformationStatus])
 case class ViewStatus(view: String, status: String, properties: Option[Map[String, String]], dependencies: Option[List[ViewStatus]])
 case class ViewStatusList(overview: Map[String, Int], views: List[ViewStatus])
 case class QueueStatusList(overview: Map[String, Int], queues: Map[String, List[RunStatus]])
@@ -41,8 +41,8 @@ object SchedoscopeJsonProtocol extends DefaultJsonProtocol {
   val formatter = DateTimeFormat.shortDateTime()
 
   implicit val runStatusFormat = jsonFormat5(RunStatus)
-  implicit val actionStatusFormat = jsonFormat5(ActionStatus)
-  implicit val actionStatusListFormat = jsonFormat2(ActionStatusList)
+  implicit val actionStatusFormat = jsonFormat5(TransformationStatus)
+  implicit val actionStatusListFormat = jsonFormat2(TransformationStatusList)
   implicit val schedoscopeCommandStatusFormat = jsonFormat4(SchedoscopeCommandStatus)
   implicit val viewStatusFormat: JsonFormat[ViewStatus] = lazyFormat(jsonFormat4(ViewStatus))
   implicit val viewStatusListFormat = jsonFormat2(ViewStatusList)
@@ -72,7 +72,7 @@ object SchedoscopeJsonProtocol extends DefaultJsonProtocol {
     if (d != null) formatter.print(d) else ""
   }
 
-  def parseActionStatus(a: ActionStatusResponse[_]): ActionStatus = {
+  def parseActionStatus(a: TransformationStatusResponse[_]): TransformationStatus = {
     val actor = getOrElse(a.actor.path.toStringWithoutAddress, "unknown")
     val typ = if (a.driver != null) getOrElse(a.driver.transformationName, "unknown") else "unknown"
     var drh = a.driverRunHandle
@@ -92,9 +92,9 @@ object SchedoscopeJsonProtocol extends DefaultJsonProtocol {
       val view = drh.transformation.asInstanceOf[Transformation].getView()
       val started = drh.started
       val runStatus = RunStatus(getOrElse(desc, "no-desc"), getOrElse(view, "no-view"), getOrElse(formatDate(started), ""), comment, None)
-      ActionStatus(actor, typ, status, Some(runStatus), None)
+      TransformationStatus(actor, typ, status, Some(runStatus), None)
     } else {
-      ActionStatus(actor, typ, status, None, None)
+      TransformationStatus(actor, typ, status, None, None)
     }
   }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestClient.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestClient.scala
@@ -15,13 +15,13 @@
  */
 package org.schedoscope.scheduler.api
 
+import scala.language.postfixOps
+import scala.language.implicitConversions
 import scala.collection.immutable.Map
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
-
 import org.schedoscope.Settings
-
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.util.Timeout
@@ -46,14 +46,14 @@ class SchedoscopeRestClient extends SchedoscopeInterface {
 
   def get[T](path: String, query: Map[String, String]): Future[T] = {
     val pipeline = path match {
-      case u: String if u.startsWith("/views") => sendReceive ~> unmarshal[ViewStatusList]
-      case u: String if u.startsWith("/actions") => sendReceive ~> unmarshal[ActionStatusList]
-      case u: String if u.startsWith("/queues") => sendReceive ~> unmarshal[QueueStatusList]
+      case u: String if u.startsWith("/views")       => sendReceive ~> unmarshal[ViewStatusList]
+      case u: String if u.startsWith("/actions")     => sendReceive ~> unmarshal[ActionStatusList]
+      case u: String if u.startsWith("/queues")      => sendReceive ~> unmarshal[QueueStatusList]
       case u: String if u.startsWith("/materialize") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/invalidate") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/newdata") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/commands") => sendReceive ~> unmarshal[List[SchedoscopeCommandStatus]]
-      case _ => throw new RuntimeException("Unsupported query path: " + path)
+      case u: String if u.startsWith("/invalidate")  => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
+      case u: String if u.startsWith("/newdata")     => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
+      case u: String if u.startsWith("/commands")    => sendReceive ~> unmarshal[List[SchedoscopeCommandStatus]]
+      case _                                         => throw new RuntimeException("Unsupported query path: " + path)
     }
     val uri = Uri.from("http", "", host, port, path) withQuery (query)
     println("Calling Schedoscope API URL: " + uri)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestClient.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestClient.scala
@@ -46,14 +46,14 @@ class SchedoscopeRestClient extends SchedoscopeInterface {
 
   def get[T](path: String, query: Map[String, String]): Future[T] = {
     val pipeline = path match {
-      case u: String if u.startsWith("/views")       => sendReceive ~> unmarshal[ViewStatusList]
-      case u: String if u.startsWith("/actions")     => sendReceive ~> unmarshal[ActionStatusList]
-      case u: String if u.startsWith("/queues")      => sendReceive ~> unmarshal[QueueStatusList]
+      case u: String if u.startsWith("/views") => sendReceive ~> unmarshal[ViewStatusList]
+      case u: String if u.startsWith("/transformations") => sendReceive ~> unmarshal[TransformationStatusList]
+      case u: String if u.startsWith("/queues") => sendReceive ~> unmarshal[QueueStatusList]
       case u: String if u.startsWith("/materialize") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/invalidate")  => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/newdata")     => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
-      case u: String if u.startsWith("/commands")    => sendReceive ~> unmarshal[List[SchedoscopeCommandStatus]]
-      case _                                         => throw new RuntimeException("Unsupported query path: " + path)
+      case u: String if u.startsWith("/invalidate") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
+      case u: String if u.startsWith("/newdata") => sendReceive ~> unmarshal[SchedoscopeCommandStatus]
+      case u: String if u.startsWith("/commands") => sendReceive ~> unmarshal[List[SchedoscopeCommandStatus]]
+      case _ => throw new RuntimeException("Unsupported query path: " + path)
     }
     val uri = Uri.from("http", "", host, port, path) withQuery (query)
     println("Calling Schedoscope API URL: " + uri)
@@ -93,8 +93,8 @@ class SchedoscopeRestClient extends SchedoscopeInterface {
     Await.result(get[ViewStatusList](s"/views/${viewUrlPath.getOrElse("")}", paramsFrom(("status", status), ("filter", filter), ("dependencies", dependencies), ("overview", overview))), 3600 seconds)
   }
 
-  def actions(status: Option[String], filter: Option[String]): ActionStatusList = {
-    Await.result(get[ActionStatusList](s"/actions", paramsFrom(("status", status), ("filter", filter))), 3600 seconds)
+  def transformations(status: Option[String], filter: Option[String]): TransformationStatusList = {
+    Await.result(get[TransformationStatusList](s"/transformations", paramsFrom(("status", status), ("filter", filter))), 3600 seconds)
   }
 
   def queues(typ: Option[String], filter: Option[String]): QueueStatusList = {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestService.scala
@@ -100,7 +100,7 @@ class SchedoscopeRestServerActor(schedoscope: SchedoscopeInterface) extends Acto
       parameters("status"?, "filter"?, "dependencies".as[Boolean]?, "typ"?, "mode" ?, "overview".as[Boolean] ?) { (status, filter, dependencies, typ, mode, overview) =>
         {
           path("actions") {
-            complete(schedoscope.actions(status, filter))
+            complete(schedoscope.transformations(status, filter))
           } ~
             path("queues") {
               complete(schedoscope.queues(typ, filter))

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeRestService.scala
@@ -99,7 +99,7 @@ class SchedoscopeRestServerActor(schedoscope: SchedoscopeInterface) extends Acto
     respondWithHeader(RawHeader("Access-Control-Allow-Origin", "*")) {
       parameters("status"?, "filter"?, "dependencies".as[Boolean]?, "typ"?, "mode" ?, "overview".as[Boolean] ?) { (status, filter, dependencies, typ, mode, overview) =>
         {
-          path("actions") {
+          path("transformations") {
             complete(schedoscope.transformations(status, filter))
           } ~
             path("queues") {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeSystem.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/api/SchedoscopeSystem.scala
@@ -15,6 +15,7 @@
  */
 package org.schedoscope.scheduler.api
 
+import scala.language.postfixOps
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import org.joda.time.LocalDateTime
@@ -28,8 +29,7 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.actorRef2Scala
 import akka.event.Logging
-import org.schedoscope.scheduler.queryActors
-import org.schedoscope.scheduler.queryActor
+import org.schedoscope.AskPattern._
 import akka.pattern.Patterns
 import org.schedoscope.dsl.views.ViewUrlParser.ParsedViewAugmentor
 import org.schedoscope.dsl.transformations.Transformation
@@ -59,7 +59,7 @@ class SchedoscopeSystem extends SchedoscopeInterface {
     val format = DateTimeFormat.forPattern("YYYYMMddHHmmss");
     val c = command match {
       case s: String => s
-      case c: Any => Named.camelToLowerUnderscore(c.getClass.getSimpleName)
+      case c: Any    => Named.camelToLowerUnderscore(c.getClass.getSimpleName)
     }
     val a = if (args.size == 0) "_" else args.filter(_.isDefined).map(_.getOrElse("_")).mkString(":")
     if (start.isDefined) {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/Driver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/Driver.scala
@@ -71,14 +71,14 @@ trait DriverRunCompletionHandler[T <: Transformation] {
 
   /**
    * This method has to be implemented for gathering information about a completed run run
-   * 
-   * As for exceptions: 
-   * 
+   *
+   * As for exceptions:
+   *
    * In case a failure within the completion handler should not cause the transformation to fail, the exception should be suppressed.
-   * 
-   * In case a failure within the completion handler should cause a restart of the driver actor and a redo of the transformation, 
+   *
+   * In case a failure within the completion handler should cause a restart of the driver actor and a redo of the transformation,
    * it should be raised as a DriverException.
-   * 
+   *
    * Any other raised exception will cause the driver run to fail and the transformation subsequently to be retried by the view actor.
    */
   def driverRunCompleted(stateOfCompletion: DriverRunState[T], run: DriverRunHandle[T])
@@ -192,8 +192,8 @@ trait Driver[T <: Transformation] {
   def driverRunCompleted(run: DriverRunHandle[T]) {
     getDriverRunState(run) match {
       case s: DriverRunSucceeded[T] => driverRunCompletionHandlers.foreach(_.driverRunCompleted(s, run))
-      case f: DriverRunFailed[T] => driverRunCompletionHandlers.foreach(_.driverRunCompleted(f, run))
-      case _ => throw DriverException("driverRunCompleted called with non-final driver run state")
+      case f: DriverRunFailed[T]    => driverRunCompletionHandlers.foreach(_.driverRunCompleted(f, run))
+      case _                        => throw DriverException("driverRunCompleted called with non-final driver run state")
     }
   }
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/FileSystemDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/FileSystemDriver.scala
@@ -25,7 +25,7 @@ import scala.Array.canBuildFrom
 import scala.collection.mutable.HashMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
-import scala.concurrent.future
+import scala.concurrent.Future
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
@@ -61,7 +61,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
    * Construct a future-based driver run handle
    */
   override def run(t: FilesystemTransformation): DriverRunHandle[FilesystemTransformation] =
-    new DriverRunHandle(this, new LocalDateTime(), t, future {
+    new DriverRunHandle(this, new LocalDateTime(), t, Future {
       doRun(t)
     })
 
@@ -86,14 +86,14 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       })
 
       case CopyFrom(from, view, recursive) => doAs(() => copy(from, view.fullPath, recursive))
-      case StoreFrom(inputStream, view) => doAs(() => storeFromStream(inputStream, view.fullPath))
-      case Copy(from, to, recursive) => doAs(() => copy(from, to, recursive))
-      case Move(from, to) => doAs(() => move(from, to))
-      case Delete(path, recursive) => doAs(() => delete(path, recursive))
-      case MkDir(path) => doAs(() => mkdirs(path))
-      case Touch(path) => doAs(() => touch(path))
+      case StoreFrom(inputStream, view)    => doAs(() => storeFromStream(inputStream, view.fullPath))
+      case Copy(from, to, recursive)       => doAs(() => copy(from, to, recursive))
+      case Move(from, to)                  => doAs(() => move(from, to))
+      case Delete(path, recursive)         => doAs(() => delete(path, recursive))
+      case MkDir(path)                     => doAs(() => mkdirs(path))
+      case Touch(path)                     => doAs(() => touch(path))
 
-      case _ => throw DriverException("FileSystemDriver can only run file transformations.")
+      case _                               => throw DriverException("FileSystemDriver can only run file transformations.")
     }
 
   /**
@@ -132,7 +132,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Storing from InputStream to ${to} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while storing InputStream to ${to}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception caught while copying InputStream to ${to}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception caught while copying InputStream to ${to}", t)
     }
   }
 
@@ -179,7 +179,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Copy from ${from} to ${to} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while copying ${from} to ${to}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception caught while copying ${from} to ${to}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception caught while copying ${from} to ${to}", t)
     }
   }
 
@@ -195,7 +195,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Deletion of ${path} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while deleting ${path}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception while deleting ${path}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception while deleting ${path}", t)
     }
 
   /**
@@ -212,7 +212,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Touching of ${path} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while touching ${path}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception while touching ${path}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception while touching ${path}", t)
     }
 
   /**
@@ -227,7 +227,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Touching of ${path} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while making dirs ${path}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception while making dirs ${path}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception while making dirs ${path}", t)
     }
 
   /**
@@ -244,7 +244,7 @@ class FileSystemDriver(val driverRunCompletionHandlerClassNames: List[String], v
       DriverRunSucceeded(this, s"Moving from ${from} to ${to} succeeded")
     } catch {
       case i: IOException => DriverRunFailed(this, s"Caught IO exception while  moving from ${from} to ${to}", i)
-      case t: Throwable => throw DriverException(s"Runtime exception while moving from ${from} to ${to}", t)
+      case t: Throwable   => throw DriverException(s"Runtime exception while moving from ${from} to ${to}", t)
     }
 
   def fileChecksums(paths: List[String], recursive: Boolean): List[String] = {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/HiveDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/HiveDriver.scala
@@ -23,7 +23,7 @@ import java.sql.Statement
 import scala.Array.canBuildFrom
 import scala.collection.JavaConversions.asScalaBuffer
 import scala.collection.mutable.Stack
-import scala.concurrent.future
+import scala.concurrent.Future
 import org.apache.commons.lang.StringUtils
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient
@@ -56,7 +56,7 @@ class HiveDriver(val driverRunCompletionHandlerClassNames: List[String], val ugi
    * Construct a future-based driver run handle
    */
   def run(t: HiveTransformation): DriverRunHandle[HiveTransformation] =
-    new DriverRunHandle[HiveTransformation](this, new LocalDateTime(), t, future {
+    new DriverRunHandle[HiveTransformation](this, new LocalDateTime(), t, Future {
       t.udfs.foreach(this.registerFunction(_))
       executeHiveQuery(replaceParameters(t.sql, t.configuration.toMap))
     })

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/MapreduceDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/MapreduceDriver.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.schedoscope.scheduler.driver
+
 import org.apache.hadoop.security.UserGroupInformation
 import org.joda.time.LocalDateTime
 import org.schedoscope.dsl.transformations.MapreduceTransformation
@@ -68,8 +69,8 @@ class MapreduceDriver(val driverRunCompletionHandlerClassNames: List[String], va
     ugi.doAs(new PrivilegedAction[DriverRunState[MapreduceTransformation]]() {
       def run(): DriverRunState[MapreduceTransformation] = {
         job.getJobState match {
-          case SUCCEEDED => DriverRunSucceeded[MapreduceTransformation](driver, s"Mapreduce job ${jobId} succeeded")
-          case PREP | RUNNING => DriverRunOngoing[MapreduceTransformation](driver, runHandle)
+          case SUCCEEDED       => DriverRunSucceeded[MapreduceTransformation](driver, s"Mapreduce job ${jobId} succeeded")
+          case PREP | RUNNING  => DriverRunOngoing[MapreduceTransformation](driver, runHandle)
           case FAILED | KILLED => DriverRunFailed[MapreduceTransformation](driver, s"Mapreduce job ${jobId} failed", DriverException(s"Failed Mapreduce job status ${job.getJobState}"))
         }
       }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/MorphlineDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/MorphlineDriver.scala
@@ -15,11 +15,12 @@
  */
 package org.schedoscope.scheduler.driver
 
+import scala.language.implicitConversions
 import java.net.URI
 import java.security.PrivilegedAction
 import scala.Array.canBuildFrom
 import scala.collection.JavaConversions.seqAsJavaList
-import scala.concurrent.future
+import scala.concurrent.Future
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
 import org.joda.time.LocalDateTime
@@ -77,7 +78,7 @@ class MorphlineDriver(val driverRunCompletionHandlerClassNames: List[String], va
   val log = LoggerFactory.getLogger(classOf[MorphlineDriver])
 
   override def run(t: MorphlineTransformation): DriverRunHandle[MorphlineTransformation] = {
-    val f = future {
+    val f = Future {
       try {
         runMorphline(createMorphline(t), t)
       } catch {
@@ -154,7 +155,7 @@ class MorphlineDriver(val driverRunCompletionHandlerClassNames: List[String], va
     else view.fields.map(field => "/" + field.n)
     val command = storageFormat match {
       case f: ExaSolution => {
-        val schema = view.fields.foldLeft(ConfigFactory.empty())((config, field) => config.withValue((if (transformation.definition == "") "/" else "") + field.n, field.t.erasure.getSimpleName()))
+        val schema = view.fields.foldLeft(ConfigFactory.empty())((config, field) => config.withValue((if (transformation.definition == "") "/" else "") + field.n, field.t.runtimeClass.getSimpleName()))
         val oConfig = commandConfig.withValue("connectionURL", f.jdbcUrl).
           withValue("keys", ConfigValueFactory.fromIterable(f.mergeKeys)).
           withValue("merge", f.merge).
@@ -185,7 +186,7 @@ class MorphlineDriver(val driverRunCompletionHandlerClassNames: List[String], va
 
       case f: JDBC => {
         log.info("creating JDBCWriter")
-        val schema = view.fields.foldLeft(ConfigFactory.empty())((config, field) => config.withValue(field.n, field.t.erasure.getSimpleName()))
+        val schema = view.fields.foldLeft(ConfigFactory.empty())((config, field) => config.withValue(field.n, field.t.runtimeClass.getSimpleName()))
         val oConfig = commandConfig.withValue("connectionURL", f.jdbcUrl).
           withValue("jdbcDriver", f.jdbcDriver).
           withValue("username", f.userName).

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/OozieDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/OozieDriver.scala
@@ -16,11 +16,9 @@
 package org.schedoscope.scheduler.driver
 
 import java.util.Properties
-
 import scala.collection.JavaConversions.asScalaSet
 import scala.collection.JavaConversions.propertiesAsScalaMap
 import scala.concurrent.duration.Duration
-
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.oozie.client.OozieClient
 import org.apache.oozie.client.WorkflowJob.Status.PREP
@@ -28,7 +26,6 @@ import org.apache.oozie.client.WorkflowJob.Status.RUNNING
 import org.apache.oozie.client.WorkflowJob.Status.SUCCEEDED
 import org.apache.oozie.client.WorkflowJob.Status.SUSPENDED
 import org.joda.time.LocalDateTime
-
 import org.schedoscope.DriverSettings
 import org.schedoscope.Settings
 import org.schedoscope.dsl.transformations.OozieTransformation
@@ -63,9 +60,9 @@ class OozieDriver(val driverRunCompletionHandlerClassNames: List[String], val cl
       val state = getJobInfo(jobId).getStatus()
 
       state match {
-        case SUCCEEDED => DriverRunSucceeded[OozieTransformation](this, s"Oozie job ${jobId} succeeded")
+        case SUCCEEDED                  => DriverRunSucceeded[OozieTransformation](this, s"Oozie job ${jobId} succeeded")
         case SUSPENDED | RUNNING | PREP => DriverRunOngoing[OozieTransformation](this, run)
-        case _ => DriverRunFailed[OozieTransformation](this, s"Oozie job ${jobId} failed", DriverException(s"Failed Oozie job status ${state}"))
+        case _                          => DriverRunFailed[OozieTransformation](this, s"Oozie job ${jobId} failed", DriverException(s"Failed Oozie job status ${state}"))
       }
     } catch {
       case e: Throwable => throw DriverException(s"Unexpected error occurred while checking run state of Oozie job ${jobId}", e)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/PigDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/PigDriver.scala
@@ -20,12 +20,10 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException
 import java.sql.Statement
-
 import scala.Array.canBuildFrom
 import scala.collection.JavaConversions.asScalaBuffer
 import scala.collection.mutable.Stack
-import scala.concurrent.future
-
+import scala.concurrent.Future
 import org.apache.commons.lang.StringUtils
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient
@@ -33,23 +31,17 @@ import org.apache.hadoop.hive.metastore.api.Function
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.thrift.protocol.TProtocolException
 import org.joda.time.LocalDateTime
-
 import org.schedoscope.DriverSettings
 import org.schedoscope.Settings
 import org.schedoscope.dsl.transformations.PigTransformation
 import org.schedoscope.dsl.transformations.Transformation.replaceParameters;
 import org.schedoscope.scheduler.driver.HiveDriver.currentConnection;
 import org.slf4j.LoggerFactory
-
 import HiveDriver.currentConnection
-
 import org.apache.pig.PigServer
 import org.apache.pig.ExecType
-
 import java.util.Properties
-
 import org.apache.pig.PigException
-
 import scala.collection.JavaConversions._
 
 /**
@@ -72,7 +64,7 @@ class PigDriver(val driverRunCompletionHandlerClassNames: List[String], val ugi:
    * Construct a future-based driver run handle
    */
   def run(t: PigTransformation): DriverRunHandle[PigTransformation] =
-    new DriverRunHandle[PigTransformation](this, new LocalDateTime(), t, future {
+    new DriverRunHandle[PigTransformation](this, new LocalDateTime(), t, Future {
       // FIXME: future work: register jars, custom functions
       executePigTransformation(t.latin, t.dirsToDelete, t.defaultLibraries, t.configuration.toMap, t.getView())
     })
@@ -98,7 +90,7 @@ class PigDriver(val driverRunCompletionHandlerClassNames: List[String], val ugi:
         } catch {
           // FIXME: do we need special handling for some exceptions here (similar to hive?)
           case e: PigException =>
-            e.printStackTrace(); DriverRunFailed(driver, s"PigException encountered while executing pig script ${actualLatin}; Stacktrace is: ${e.getStackTraceString}", e)
+            DriverRunFailed(driver, s"PigException encountered while executing pig script ${actualLatin}; Stacktrace is: ${e.getStackTrace}", e)
           case t: Throwable => throw DriverException(s"Runtime exception while executing pig script ${actualLatin}", t)
         }
       }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/driver/ShellDriver.scala
@@ -1,12 +1,13 @@
 package org.schedoscope.scheduler.driver
 
+import scala.language.reflectiveCalls
 import org.schedoscope.dsl.transformations.ShellTransformation
 import org.schedoscope.DriverSettings
 import org.schedoscope.Settings
 import org.joda.time.LocalDateTime
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
-import scala.concurrent.future
+import scala.concurrent.Future
 import scala.collection.JavaConversions.mapAsJavaMap
 import java.lang.InterruptedException
 import java.io.File
@@ -31,7 +32,7 @@ class ShellDriver(val driverRunCompletionHandlerClassNames: List[String]) extend
    * Construct a future-based driver run handle
    */
   def run(t: ShellTransformation): DriverRunHandle[ShellTransformation] =
-    new DriverRunHandle(this, new LocalDateTime(), t, future {
+    new DriverRunHandle(this, new LocalDateTime(), t, Future {
       doRun(t)
     })
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
@@ -22,7 +22,6 @@ import org.schedoscope.scheduler.driver.DriverRunState
 import org.schedoscope.scheduler.driver.DriverRunSucceeded
 import org.schedoscope.dsl.transformations.Transformation
 import org.schedoscope.dsl.View
-
 import akka.actor.ActorRef
 
 /**
@@ -229,7 +228,7 @@ case class NoDataAvailable(view: View) extends CommandResponse
 
 /**
  * A view actor notifying a depending view that it has materialized
- * 
+ *
  * @param view View that has been changed
  * @param incomplete true of not all transitive dependencies had data available
  * @param transformationTimeStamp timestamp of the oldest? transformation in that dependency tree

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
@@ -37,7 +37,7 @@ case class Failed(view: View) extends Failure
 /**
  * Driver actor signaling a failure of a transfomation that requires a retry by the receiving view actor.
  */
-case class ActionFailure[T <: Transformation](driverRunHandle: DriverRunHandle[T], driverRunState: DriverRunFailed[T]) extends Failure
+case class TransformationFailure[T <: Transformation](driverRunHandle: DriverRunHandle[T], driverRunState: DriverRunFailed[T]) extends Failure
 
 /**
  * Superclass for commands sent to actors.
@@ -68,18 +68,18 @@ case class SetViewVersion(view: View) extends CommandRequest
 case class LogTransformationTimestamp(view: View, timestamp: Long) extends CommandRequest
 
 /**
- * Command to kill a running transformation / action. Actual outcome depends on the ability of the
+ * Command to kill a running transformation. Actual outcome depends on the ability of the
  * associated driver to be able to do that.
  */
-case class KillAction() extends CommandRequest
+case class KillCommand() extends CommandRequest
 
 /**
  * Command to driver actors to instruct their drivers to deploy their resources (e.g. UDFS) to the distributed file system
  */
-case class Deploy() extends CommandRequest
+case class DeployCommand() extends CommandRequest
 
 /**
- * Used by driver actors to poll the actions manager actor for a new piece of work to be executed.
+ * Used by driver actors to poll the transformation manager actor for a new piece of work to be executed.
  */
 case class PollCommand(typ: String) extends CommandRequest
 
@@ -91,19 +91,19 @@ case class PollCommand(typ: String) extends CommandRequest
 case class CommandWithSender(command: AnyRef, sender: ActorRef) extends CommandRequest
 
 /**
- * Request to the actions manager to generate a summary of currently running actions
+ * Request to the transformation manager to generate a summary of currently running actions
  */
-case class GetActions() extends CommandRequest
+case class GetTransformations() extends CommandRequest
 
 /**
- * Request to the actions manager to retrieve the contents and size of the  worker queues
+ * Request to the tranformation manager to retrieve the contents and size of the transformation queues
  */
 case class GetQueues() extends CommandRequest
 
 /**
- * Request to the actions manager to return the state of all driver actors
+ * Request to the transformation manager to return the state of all driver actors
  */
-case class GetActionStatusList(statusRequester: ActorRef, actionQueueStatus: Map[String, List[String]], driverActors: Seq[ActorRef]) extends CommandRequest
+case class GetTransformationStatusList(statusRequester: ActorRef, transformationQueueStatus: Map[String, List[String]], driverActors: Seq[ActorRef]) extends CommandRequest
 
 /**
  * Request to the view manager actor to retrieve information of the currently instantiated views
@@ -115,7 +115,7 @@ case class GetActionStatusList(statusRequester: ActorRef, actionQueueStatus: Map
 case class GetViews(views: Option[List[View]], status: Option[String], filter: Option[String], dependencies: Boolean = false)
 
 /**
- *  Request to the actions manager to return the state of all drivers
+ *  Request to the view manager to return the state of all views.
  */
 case class GetViewStatusList(statusRequester: ActorRef, viewActors: Iterable[ActorRef]) extends CommandRequest
 
@@ -157,9 +157,9 @@ case class Retry() extends CommandRequest
 sealed class CommandResponse
 
 /**
- * Driver actor notifying the actions manager actor of successful resource deployment.
+ * Driver actor notifying the transformation manager actor of successful resource deployment.
  */
-case class DeployActionSuccess() extends CommandResponse
+case class DeployCommandSuccess() extends CommandResponse
 
 /**
  * Schema actor or metadata logger notifying view manager actor or view actor of successful schema action.
@@ -167,26 +167,26 @@ case class DeployActionSuccess() extends CommandResponse
 case class SchemaActionSuccess() extends CommandResponse
 
 /**
- * Driver actor notifying view actor of successful transformation action.
+ * Driver actor notifying view actor of successful transformation.
  *
  * @param driverRunHandle RunHandle of the executing driver
  * @param driverRunState return state of the driver
  */
-case class ActionSuccess[T <: Transformation](driverRunHandle: DriverRunHandle[T], driverRunState: DriverRunSucceeded[T]) extends CommandResponse
+case class TransformationSuccess[T <: Transformation](driverRunHandle: DriverRunHandle[T], driverRunState: DriverRunSucceeded[T]) extends CommandResponse
 
 /**
- * Response message of action manager actor with state of queues
- * @param actionQueues List of queue states of type
+ * Response message of transformation manager actor with state of queues
+ * @param transformationQueues List of queue states of type
  */
-case class QueueStatusListResponse(val actionQueues: Map[String, List[AnyRef]]) extends CommandResponse
+case class QueueStatusListResponse(val transformationQueues: Map[String, List[AnyRef]]) extends CommandResponse
 
 /**
- * Response message of action manager actor with state of actions
+ * Response message of transformation manager actor with state of actions
  *
- * @param actionsStatusList List of entities of ActionStatusResponse
- * @see ActionStatusResponse
+ * @param actionsStatusList List of entities of TransformationStatusResponse
+ * @see TransformationStatusResponse
  */
-case class ActionStatusListResponse(val actionStatusList: List[ActionStatusResponse[_]]) extends CommandResponse
+case class TransformationStatusListResponse(val transformationStatusList: List[TransformationStatusResponse[_]]) extends CommandResponse
 
 /**
  * Response message of view manager actor with state of view actors
@@ -197,14 +197,14 @@ case class ActionStatusListResponse(val actionStatusList: List[ActionStatusRespo
 case class ViewStatusListResponse(viewStatusList: List[ViewStatusResponse]) extends CommandResponse
 
 /**
- * Driver actor responding to the action manager actor with the state of the running transformation
+ * Driver actor responding to the transformation manager actor with the state of the running transformation
  *
  * @param message Textual description of state
  * @param message Reference to the driver actor
  * @param driverRunHandle runHandle of a running transformation
  * @param driverRunState state of a running transformation
  */
-case class ActionStatusResponse[T <: Transformation](val message: String, val actor: ActorRef, val driver: Driver[T], driverRunHandle: DriverRunHandle[T], driverRunStatus: DriverRunState[T]) extends CommandResponse
+case class TransformationStatusResponse[T <: Transformation](val message: String, val actor: ActorRef, val driver: Driver[T], driverRunHandle: DriverRunHandle[T], driverRunStatus: DriverRunState[T]) extends CommandResponse
 
 /**
  * View actor responding to the view manager actor with the state of the view

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
@@ -243,7 +243,7 @@ class SchemaManager(val metastoreClient: IMetaStoreClient, val connection: Conne
       val sd = table.getSd().deepCopy()
       sd.setLocation(v.fullPath)
 
-      (v.partitionSpec.replaceFirst("/", "") -> new Partition(v.partitionValues, v.dbName, v.n, now, now, sd, HashMap[String, String]()))
+      (v.partitionSpec.replaceFirst("/", "") -> new Partition(v.partitionValues(), v.dbName, v.n, now, now, sd, HashMap[String, String]()))
     }.toMap
   }
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -17,7 +17,6 @@
 package org.schedoscope.schema.ddl
 
 import org.schedoscope.dsl.Structure
-
 import org.schedoscope.dsl.View
 import org.schedoscope.dsl.storageformats._
 
@@ -48,7 +47,7 @@ object HiveQl {
 
   def commentDdl(view: View): String = view.comment match {
     case Some(c) => s"COMMENT '${c}'"
-    case None => ""
+    case None    => ""
   }
 
   def fieldsDdl(structure: Structure): String = structure
@@ -91,12 +90,12 @@ ${if (collectionItemTerminator != null) s"\tCOLLECTION ITEMS TERMINATED BY \42${
 ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY \42${mapKeyTerminator}\42" else ""}
 \tSTORED AS TEXTFILE"""
     case e: ExternalStorageFormat => "STORED BY 'org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler'"
-    case _ => "STORED AS TEXTFILE"
+    case _                        => "STORED AS TEXTFILE"
   }
 
   def locationDdl(view: View): String = view.tablePath match {
     case "" => ""
-    case l => if (!view.isExternal) s"LOCATION '${l}'" else ""
+    case l  => if (!view.isExternal) s"LOCATION '${l}'" else ""
   }
 
   def ddl(view: View): String = s"""

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/FieldSequentialValue.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/FieldSequentialValue.scala
@@ -17,7 +17,6 @@ package org.schedoscope.test
 
 import java.text.SimpleDateFormat
 import java.util.Date
-
 import org.schedoscope.dsl.FieldLike
 import org.schedoscope.dsl.Structure
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/FillableStructure.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/FillableStructure.scala
@@ -16,7 +16,6 @@
 package org.schedoscope.test
 
 import scala.collection.mutable.HashMap
-
 import org.schedoscope.dsl.FieldLike
 import org.schedoscope.dsl.Structure
 
@@ -44,7 +43,7 @@ trait values extends Structure {
 
   override def equals(o: Any) = o match {
     case that: values => this.fs.equals(that.fs)
-    case _ => false
+    case _            => false
   }
 
   override def toString = s"Structure(${fs.mkString(",")})"

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/FillableView.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/FillableView.scala
@@ -53,7 +53,7 @@ trait rows extends View {
   moduleNameBuilder = () => Named.camelToLowerUnderscore(getClass().getSuperclass.getPackage().getName()).replaceAll("[.]", "_")
 
   tablePathBuilder = (env: String) => resources().hiveWarehouseDir + ("/hdp/" + env.toLowerCase() + "/" + module.replaceFirst("app", "applications")).replaceAll("_", "/") + (if (additionalStoragePathPrefix != null) "/" + additionalStoragePathPrefix else "") + "/" + n + (if (additionalStoragePathSuffix != null) "/" + additionalStoragePathSuffix else "")
-  
+
   // unify storage format
   storedAs(localTestResources.textStorage)
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/TestableView.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/TestableView.scala
@@ -16,9 +16,7 @@
 package org.schedoscope.test
 
 import scala.collection.mutable.ListBuffer
-
 import org.apache.hadoop.fs.Path
-
 import org.schedoscope.scheduler.driver.Driver
 import org.schedoscope.dsl.FieldLike
 import org.schedoscope.dsl.Structure
@@ -38,21 +36,21 @@ trait test extends TestableView {
 
   var driver: () => Driver[Transformation] = () => {
     this.transformation() match {
-      case t: HiveTransformation => resources().hiveDriver.asInstanceOf[Driver[Transformation]]
-      case t: OozieTransformation => resources().oozieDriver.asInstanceOf[Driver[Transformation]]
-      case t: PigTransformation => resources().pigDriver.asInstanceOf[Driver[Transformation]]
-      case t: MapreduceTransformation => resources().mapreduceDriver.asInstanceOf[Driver[Transformation]]
+      case t: HiveTransformation       => resources().hiveDriver.asInstanceOf[Driver[Transformation]]
+      case t: OozieTransformation      => resources().oozieDriver.asInstanceOf[Driver[Transformation]]
+      case t: PigTransformation        => resources().pigDriver.asInstanceOf[Driver[Transformation]]
+      case t: MapreduceTransformation  => resources().mapreduceDriver.asInstanceOf[Driver[Transformation]]
       case t: FilesystemTransformation => resources().fileSystemDriver.asInstanceOf[Driver[Transformation]]
     }
   }
 
   val deps = ListBuffer[View with rows]()
 
-  def then() {
-    then(sortedBy = null)
+  def `then`() {
+    `then`(sortedBy = null)
   }
 
-  def then(sortedBy: FieldLike[_]) {
+  def `then`(sortedBy: FieldLike[_]) {
     deploySchema()
 
     deps.map(d => {
@@ -61,8 +59,8 @@ trait test extends TestableView {
 
     val trans = this.transformation() match {
       case ot: OozieTransformation => deployWorkflow(ot)
-      case ht: HiveTransformation => deployFunctions(ht)
-      case t: Transformation => t
+      case ht: HiveTransformation  => deployFunctions(ht)
+      case t: Transformation       => t
     }
 
     val d = driver()

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/ViewSerDe.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/ViewSerDe.scala
@@ -41,12 +41,12 @@ object ViewSerDe {
 
   private def serializeCell(c: Any, inList: Boolean, format: TextFile): String = {
     c match {
-      case null => { "\\N" }
+      case null                     => { "\\N" }
       case s: Structure with values => { s.fields.map(f => serializeCell(s.fs(f.n), false, format)).mkString(if (inList) format.mapKeyTerminator else format.collectionItemTerminator) }
-      case l: List[_] => { l.map(e => serializeCell(e, true, format)).mkString(format.collectionItemTerminator) }
-      case m: Map[_, _] => { m.map(e => serializeCell(e._1, false, format) + format.mapKeyTerminator + serializeCell(e._2, false, format)).mkString(format.collectionItemTerminator) }
-      case d: Date => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(d)
-      case _ => { c.toString }
+      case l: List[_]               => { l.map(e => serializeCell(e, true, format)).mkString(format.collectionItemTerminator) }
+      case m: Map[_, _]             => { m.map(e => serializeCell(e._1, false, format) + format.mapKeyTerminator + serializeCell(e._2, false, format)).mkString(format.collectionItemTerminator) }
+      case d: Date                  => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(d)
+      case _                        => { c.toString }
     }
   }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/resources/LocalTestResources.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/resources/LocalTestResources.scala
@@ -21,9 +21,7 @@ import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Properties
-
 import scala.Array.canBuildFrom
-
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
@@ -38,7 +36,6 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREWAREHOUSE
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars.PLAN_SERIALIZATION
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_LOG_INCREMENTAL_PLAN_PROGRESS_INTERVAL
-
 import net.lingala.zip4j.core.ZipFile
 
 class LocalTestResources extends TestResources {

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
@@ -37,6 +37,7 @@ import test.eci.datahub.ViewWithDefaultParams
 import org.schedoscope.dsl.storageformats.TextFile
 import org.schedoscope.dsl.storageformats.Parquet
 import org.schedoscope.dsl.transformations.NoOp
+
 class DslTest extends FlatSpec with Matchers {
 
   "A view" should "be instantiable without new" in {

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
@@ -335,6 +335,19 @@ class DslTest extends FlatSpec with Matchers {
         dateString should be >= "20131202"
     }
   }
+  
+  it should "have the same urlPath as the one they were dynamically constructed with" in {
+    val views = View.viewsFromUrl("dev", "test.eci.datahub/Product/EC0106/2014/02/24/20140224")
+
+    views.length shouldBe 1
+
+    
+    val product = views.head.asInstanceOf[Product]
+    
+    val productParameters = product.partitionParameters
+    
+    product.urlPath shouldBe "test.eci.datahub/Product/EC0106/2014/02/24/20140224"
+  }
 
   it should "be queryable" in {
     val views = View.viewsInPackage("test.eci.datahub")

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -16,7 +16,6 @@
 package org.schedoscope.dsl.transformations
 
 import java.util.Date
-
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/OozieWFTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/OozieWFTest.scala
@@ -19,16 +19,15 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.schedoscope.dsl.transformations.OozieTransformation.configurationFromResource;
-
 import org.schedoscope.dsl.Parameter
 import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.dsl.View
 
 case class Productfeed(
-  ecShopCode: Parameter[String],
-  year: Parameter[String],
-  month: Parameter[String],
-  day: Parameter[String]) extends View {
+    ecShopCode: Parameter[String],
+    year: Parameter[String],
+    month: Parameter[String],
+    day: Parameter[String]) extends View {
 
   val artNumber = fieldOf[String]
   val artName = fieldOf[String]

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/views/DateParameterizationTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/views/DateParameterizationTest.scala
@@ -24,7 +24,7 @@ class DailyParameterizationTest extends FlatSpec with Matchers {
   "prevDay" should "compute the previous date" in {
     val prevDate = DateParameterizationUtils.prevDay(p("2014"), p("01"), p("01")) match {
       case Some((prevYear, prevMonth, prevDay)) => (prevYear, prevMonth, prevDay)
-      case None => null
+      case None                                 => null
     }
 
     prevDate shouldEqual ("2013", "12", "31")
@@ -39,7 +39,7 @@ class DailyParameterizationTest extends FlatSpec with Matchers {
   "prevMonth" should "compute the previous month" in {
     val prevDate = DateParameterizationUtils.prevMonth(p("2014"), p("01")) match {
       case Some((prevYear, prevMonth)) => (prevYear, prevMonth)
-      case None => null
+      case None                        => null
     }
 
     prevDate shouldEqual ("2013", "12")

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/views/ViewUrlParserTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/views/ViewUrlParserTest.scala
@@ -17,14 +17,12 @@ package org.schedoscope.dsl.views
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.schedoscope.dsl.Parameter
 import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.dsl.View.t
 import org.schedoscope.dsl.views.ViewUrlParser.ParsedView
 import org.schedoscope.dsl.views.ViewUrlParser.parse
 import org.schedoscope.dsl.views.ViewUrlParser.parseParameters
-
 import test.eci.datahub.Brand
 import test.eci.datahub.Product
 

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/HiveDriverTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/HiveDriverTest.scala
@@ -17,7 +17,6 @@ package org.schedoscope.scheduler.driver
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.schedoscope.DriverTests
 import org.schedoscope.dsl.transformations.HiveTransformation
 import org.schedoscope.test.resources.LocalTestResources

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/OozieDriverTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/OozieDriverTest.scala
@@ -18,7 +18,6 @@ package org.schedoscope.scheduler.driver
 import org.apache.hadoop.fs.Path
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.schedoscope.DriverTests
 import org.schedoscope.OozieTests
 import org.schedoscope.dsl.transformations.OozieTransformation

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/ShellDriverTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/ShellDriverTest.scala
@@ -1,4 +1,5 @@
 package org.schedoscope.scheduler.driver
+
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.schedoscope.DriverTests
@@ -26,7 +27,7 @@ class ShellDriverTest extends FlatSpec with Matchers {
     driverRunState shouldBe a[DriverRunSucceeded[_]]
   }
 
-  ignore should "execute another shell tranformations synchronously" taggedAs (DriverTests, ShellTests) in {
+  it should "execute another shell tranformations synchronously" taggedAs (DriverTests, ShellTests) in {
     val driverRunState = driver.runAndWait(ShellTransformation("echo error >/dev/stderr;zcat /usr/share/man/man1/*gz"))
     driverRunState shouldBe a[DriverRunSucceeded[_]]
   }

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/TestFolder.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/driver/TestFolder.scala
@@ -16,12 +16,11 @@
 package org.schedoscope.scheduler.driver
 
 import java.io.File
-
 import org.apache.commons.io.FileUtils
 import org.scalatest.AbstractSuite
 import org.scalatest.Suite
 
-trait TestFolder extends AbstractSuite { self: Suite =>
+trait TestFolder extends Suite { self: Suite =>
   var testFolder: File = _
   var inputFolder: File = _
   var outputFolder: File = _

--- a/schedoscope-core/src/test/scala/org/schedoscope/test/HiveTestFrameworkTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/test/HiveTestFrameworkTest.scala
@@ -17,11 +17,9 @@ package org.schedoscope.test
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.schedoscope.DriverTests
 import org.schedoscope.dsl.Field.v
 import org.schedoscope.dsl.Parameter.p
-
 import test.eci.datahub.Click
 import test.eci.datahub.ClickOfEC0101
 
@@ -53,7 +51,7 @@ class HiveTestFrameworkTest extends FlatSpec with Matchers {
   "Hive test framework" should "execute hive transformations locally" taggedAs (DriverTests) in {
     new ClickOfEC0101(p("2014"), p("01"), p("01")) with test {
       basedOn(ec0101Clicks, ec0106Clicks)
-      then()
+      `then`()
       numRows shouldBe 3
       row(v(id) shouldBe "event01",
         v(url) shouldBe "http://ec0101.com/url1")

--- a/schedoscope-core/src/test/scala/org/schedoscope/test/OozieTestFrameworkTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/test/OozieTestFrameworkTest.scala
@@ -17,12 +17,10 @@ package org.schedoscope.test
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.schedoscope.DriverTests
 import org.schedoscope.OozieTests
 import org.schedoscope.dsl.Field.v
 import org.schedoscope.dsl.Parameter.p
-
 import test.eci.datahub.Click
 import test.eci.datahub.ClickOfEC0101ViaOozie
 
@@ -59,7 +57,7 @@ class OozieTestFrameworkTest extends FlatSpec with Matchers {
         ("nameNode" -> cluster().getNameNodeUri),
         ("input" -> s"${ec0101Clicks.fullPath}/*"),
         ("output" -> s"${this.fullPath}/"))
-      then()
+      `then`()
       numRows shouldBe 3
       row(v(id) shouldBe "event01",
         v(url) shouldBe "http://ec0101.com/url1")

--- a/schedoscope-core/src/test/scala/test/eci/datahub/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/eci/datahub/TestViews.scala
@@ -16,7 +16,6 @@
 package test.eci.datahub
 
 import java.util.Date
-
 import org.schedoscope.dsl.Parameter
 import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.dsl.Structure
@@ -37,8 +36,8 @@ import scala.io.Source
 
 case class Brand(
   ecNr: Parameter[String]) extends View
-  with Id
-  with JobMetadata {
+    with Id
+    with JobMetadata {
 
   comment("In this example, brands are per shop but time invariant")
 
@@ -53,10 +52,10 @@ case class Product(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with Id
-  with PointOccurrence
-  with JobMetadata
-  with DailyParameterization {
+    with Id
+    with PointOccurrence
+    with JobMetadata
+    with DailyParameterization {
 
   comment("In this example, shops have different products each day")
 
@@ -72,9 +71,9 @@ case class ProductBrand(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with PointOccurrence
-  with JobMetadata
-  with DailyParameterization {
+    with PointOccurrence
+    with JobMetadata
+    with DailyParameterization {
 
   comment("ProductBrand joins brands with products")
 
@@ -128,7 +127,7 @@ case class AvroView(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with DailyParameterization {
+    with DailyParameterization {
 
   val aField = fieldOf[String]
   val anotherField = fieldOf[String]
@@ -139,11 +138,11 @@ case class AvroView(
 }
 
 case class ViewWithDefaultParams(
-  ecNr: Parameter[String],
-  year: Parameter[String],
-  month: Parameter[String],
-  day: Parameter[String],
-  defaultParameter: Int = 2) extends View {
+    ecNr: Parameter[String],
+    year: Parameter[String],
+    month: Parameter[String],
+    day: Parameter[String],
+    defaultParameter: Int = 2) extends View {
 }
 
 case class Click(
@@ -151,8 +150,8 @@ case class Click(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with Id
-  with DailyParameterization {
+    with Id
+    with DailyParameterization {
 
   val url = fieldOf[String]
 }
@@ -161,8 +160,8 @@ case class ClickOfEC0101(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with Id
-  with DailyParameterization {
+    with Id
+    with DailyParameterization {
 
   val url = fieldOf[String]
 
@@ -180,8 +179,8 @@ case class ClickOfEC0101ViaOozie(
   year: Parameter[String],
   month: Parameter[String],
   day: Parameter[String]) extends View
-  with Id
-  with DailyParameterization {
+    with Id
+    with DailyParameterization {
 
   val url = fieldOf[String]
 

--- a/schedoscope-tutorial/pom.xml
+++ b/schedoscope-tutorial/pom.xml
@@ -15,24 +15,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.10</artifactId>
-			<version>2.2.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>hadoop-launcher</groupId>
-			<artifactId>hadoop-launcher</artifactId>
-			<version>0.1.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>minioozie</groupId>
-			<artifactId>minioozie</artifactId>
-			<version>0.1.7</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
 			<version>1.1.2</version>
@@ -108,6 +90,24 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_2.11</artifactId>
+			<version>2.2.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>hadoop-launcher</groupId>
+			<artifactId>hadoop-launcher</artifactId>
+			<version>0.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>minioozie</groupId>
+			<artifactId>minioozie</artifactId>
+			<version>0.1.7</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -115,16 +115,26 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.3</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.6</version>
+				<version>2.7</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
@@ -156,7 +166,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.7</version>
+				<version>2.19</version>
 				<configuration>
 					<skipTests>true</skipTests>
 				</configuration>
@@ -165,20 +175,31 @@
 				<!-- see http://davidb.github.com/scala-maven-plugin -->
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.2.2</version>
+				<configuration>
+					<recompileMode>incremental</recompileMode>
+					<args>
+						<arg>-target:jvm-1.7</arg>
+					</args>
+					<javacArgs>
+						<javacArg>-source</javacArg>
+						<javacArg>1.7</javacArg>
+						<javacArg>-target</javacArg>
+						<javacArg>1.7</javacArg>
+					</javacArgs>
+				</configuration>
 				<executions>
 					<execution>
+						<id>scala-compile</id>
 						<goals>
 							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>scala-test-compile</id>
+						<goals>
 							<goal>testCompile</goal>
 						</goals>
-						<configuration>
-							<args>
-								<arg>-make:transitive</arg>
-								<arg>-dependencyfile</arg>
-								<arg>${project.build.directory}/.scala_dependencies</arg>
-							</args>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Restaurants.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Restaurants.scala
@@ -28,11 +28,11 @@ import schedoscope.example.osm.Globals._
 import org.schedoscope.dsl.storageformats.Parquet
 
 case class Restaurants() extends View
-  with Id
-  with JobMetadata {
+    with Id
+    with JobMetadata {
 
-  val restaurant_name = fieldOf[String]
-  val restaurant_type = fieldOf[String]
+  val restaurantName = fieldOf[String]
+  val restaurantType = fieldOf[String]
   val area = fieldOf[String]
 
   dependsOn { () =>

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Shops.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Shops.scala
@@ -28,11 +28,11 @@ import schedoscope.example.osm.Globals._
 import org.schedoscope.dsl.storageformats.Parquet
 
 case class Shops() extends View
-  with Id
-  with JobMetadata {
+    with Id
+    with JobMetadata {
 
-  val shop_name = fieldOf[String]
-  val shop_type = fieldOf[String]
+  val shopName = fieldOf[String]
+  val shopType = fieldOf[String]
   val area = fieldOf[String]
 
   dependsOn { () =>

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Trainstations.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datahub/Trainstations.scala
@@ -27,10 +27,10 @@ import org.schedoscope.dsl.transformations.PigTransformation
 import org.schedoscope.dsl.transformations.PigTransformation.scriptFromResource
 
 case class Trainstations() extends View
-  with Id
-  with JobMetadata {
+    with Id
+    with JobMetadata {
 
-  val station_name = fieldOf[String]
+  val stationName = fieldOf[String]
   val area = fieldOf[String]
 
   val nodes = dependsOn(() =>

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datamart/ShopProfiles.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/datamart/ShopProfiles.scala
@@ -28,15 +28,15 @@ import schedoscope.example.osm.datahub.Trainstations
 import schedoscope.example.osm.datahub.Restaurants
 
 case class ShopProfiles() extends View
-  with Id
-  with JobMetadata {
+    with Id
+    with JobMetadata {
 
-  val shop_name = fieldOf[String]
-  val shop_type = fieldOf[String]
+  val shopName = fieldOf[String]
+  val shopType = fieldOf[String]
   val area = fieldOf[String]
-  val cnt_competitors = fieldOf[Int]
-  val cnt_restaurants = fieldOf[Int]
-  val cnt_trainstations = fieldOf[Int]
+  val cntCompetitors = fieldOf[Int]
+  val cntRestaurants = fieldOf[Int]
+  val cntTrainstations = fieldOf[Int]
 
   dependsOn { () => Shops() }
   dependsOn { () => Restaurants() }

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/processed/Nodes.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/processed/Nodes.scala
@@ -33,13 +33,13 @@ import org.schedoscope.dsl.Parameter
 case class Nodes(
   year: Parameter[String],
   month: Parameter[String]) extends View
-  with MonthlyParameterization
-  with Id
-  with PointOccurrence
-  with JobMetadata {
+    with MonthlyParameterization
+    with Id
+    with PointOccurrence
+    with JobMetadata {
 
   val version = fieldOf[Int]
-  val user_id = fieldOf[Int]
+  val userId = fieldOf[Int]
   val longitude = fieldOf[Double]
   val latitude = fieldOf[Double]
   val geohash = fieldOf[String]

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/processed/NodesWithGeohash.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/processed/NodesWithGeohash.scala
@@ -31,7 +31,7 @@ import schedoscope.example.osm.mapreduce.GeohashMapper
 case class NodesWithGeohash() extends View {
   val id = fieldOf[Long]
   val version = fieldOf[Int]
-  val user_id = fieldOf[Int]
+  val userId = fieldOf[Int]
   val tstamp = fieldOf[String]
   val longitude = fieldOf[Double]
   val latitude = fieldOf[Double]

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/stage/NodeTags.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/stage/NodeTags.scala
@@ -22,7 +22,7 @@ import org.schedoscope.dsl.storageformats.TextFile
 case class NodeTags() extends View {
 
   // Declare each column of the TSV-file
-  val node_id = fieldOf[Long]
+  val nodeId = fieldOf[Long]
   val key = fieldOf[String]
   val value = fieldOf[String]
 

--- a/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/stage/Nodes.scala
+++ b/schedoscope-tutorial/src/main/scala/schedoscope/example/osm/stage/Nodes.scala
@@ -24,7 +24,7 @@ case class Nodes() extends View {
   // Declare each column of the TSV-file
   val id = fieldOf[Long]
   val version = fieldOf[Int]
-  val user_id = fieldOf[Int]
+  val userId = fieldOf[Int]
   val tstamp = fieldOf[String]
   val longitude = fieldOf[Double]
   val latitude = fieldOf[Double]

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
@@ -54,8 +54,8 @@ case class RestaurantsTest() extends FlatSpec
       then()
       numRows shouldBe 3
       row(v(id) shouldBe "267622930",
-        v(restaurant_name) shouldBe "Cuore Mio",
-        v(restaurant_type) shouldBe "italian",
+        v(restaurantName) shouldBe "Cuore Mio",
+        v(restaurantType) shouldBe "italian",
         v(area) shouldBe "t1y06x1")
     }
   }

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
@@ -50,12 +50,12 @@ case class ShopsTest() extends FlatSpec
       then()
       numRows shouldBe 3
       row(v(id) shouldBe "122317",
-        v(shop_name) shouldBe "Netto",
-        v(shop_type) shouldBe "supermarket",
+        v(shopName) shouldBe "Netto",
+        v(shopType) shouldBe "supermarket",
         v(area) shouldBe "t1y140d")
       row(v(id) shouldBe "274850441",
-        v(shop_name) shouldBe "Schanzenbaeckerei",
-        v(shop_type) shouldBe "bakery",
+        v(shopName) shouldBe "Schanzenbaeckerei",
+        v(shopType) shouldBe "bakery",
         v(area) shouldBe "t1y87ki")
     }
   }

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
@@ -53,10 +53,10 @@ case class TrainstationsTest() extends FlatSpec
       then()
       numRows shouldBe 3
       row(v(id) shouldBe "122317",
-        v(station_name) shouldBe "Hagenbecks Tierpark",
+        v(stationName) shouldBe "Hagenbecks Tierpark",
         v(area) shouldBe "t1y140d")
       row(v(id) shouldBe "274850441",
-        v(station_name) shouldBe "Boenningstedt",
+        v(stationName) shouldBe "Boenningstedt",
         v(area) shouldBe "t1y87ki")
     }
   }

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datamart/ShopProfilesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datamart/ShopProfilesTest.scala
@@ -29,40 +29,40 @@ case class ShopProfilesTest() extends FlatSpec
 
   val shops = new Shops() with rows {
     set(v(id, "122546"),
-      v(shop_name, "Netto"),
-      v(shop_type, "supermarket"),
+      v(shopName, "Netto"),
+      v(shopType, "supermarket"),
       v(area, "t1y87ki"))
     set(v(id, "274850441"),
-      v(shop_name, "Schanzenbaeckerei"),
-      v(shop_type, "bakery"),
+      v(shopName, "Schanzenbaeckerei"),
+      v(shopType, "bakery"),
       v(area, "t1y87ki"))
     set(v(id, "279023080"),
-      v(shop_name, "Edeka Linow"),
-      v(shop_type, "supermarket"),
+      v(shopName, "Edeka Linow"),
+      v(shopType, "supermarket"),
       v(area, "t1y77d8"))
   }
 
   val restaurants = new Restaurants() with rows {
     set(v(id, "267622930"),
-      v(restaurant_name, "Cuore Mio"),
-      v(restaurant_type, "italian"),
+      v(restaurantName, "Cuore Mio"),
+      v(restaurantType, "italian"),
       v(area, "t1y06x1"))
     set(v(id, "288858596"),
-      v(restaurant_name, "Jam Jam"),
-      v(restaurant_type, "japanese"),
+      v(restaurantName, "Jam Jam"),
+      v(restaurantType, "japanese"),
       v(area, "t1y87ki"))
     set(v(id, "302281521"),
-      v(restaurant_name, "Walddoerfer Croque Cafe"),
-      v(restaurant_type, "burger"),
+      v(restaurantName, "Walddoerfer Croque Cafe"),
+      v(restaurantType, "burger"),
       v(area, "t1y17m9"))
   }
 
   val trainstations = new Trainstations() with rows {
     set(v(id, "122317"),
-      v(station_name, "Hagenbecks Tierpark"),
+      v(stationName, "Hagenbecks Tierpark"),
       v(area, "t1y140d"))
     set(v(id, "122317"),
-      v(station_name, "Boenningstedt"),
+      v(stationName, "Boenningstedt"),
       v(area, "t1y87ki"))
   }
 
@@ -72,12 +72,12 @@ case class ShopProfilesTest() extends FlatSpec
       then()
       numRows shouldBe 3
       row(v(id) shouldBe "122546",
-        v(shop_name) shouldBe "Netto",
-        v(shop_type) shouldBe "supermarket",
+        v(shopName) shouldBe "Netto",
+        v(shopType) shouldBe "supermarket",
         v(area) shouldBe "t1y87ki",
-        v(cnt_competitors) shouldBe 1,
-        v(cnt_restaurants) shouldBe 1,
-        v(cnt_trainstations) shouldBe 1)
+        v(cntCompetitors) shouldBe 1,
+        v(cntRestaurants) shouldBe 1,
+        v(cntTrainstations) shouldBe 1)
     }
   }
 }

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
@@ -30,30 +30,30 @@ case class NodesTest() extends FlatSpec
     set(v(id, 122317L),
       v(tstamp, "2014-09-17T13:49:26Z"),
       v(version, 7),
-      v(user_id, 50299),
+      v(userId, 50299),
       v(longitude, 10.0232716),
       v(latitude, 53.5282633),
       v(geohash, "t1y140djfcq0"))
     set(v(id, 122318L),
       v(tstamp, "2013-06-17 15:49:26Z"),
       v(version, 6),
-      v(user_id, 50299),
+      v(userId, 50299),
       v(longitude, 10.0243161),
       v(latitude, 53.5297589),
       v(geohash, "t1y140g5vgcn"))
   }
 
   val nodeTags = new NodeTags() with rows {
-    set(v(node_id, 122317L),
+    set(v(nodeId, 122317L),
       v(key, "TMC:cid_58:tabcd_1:Class"),
       v(value, "Point"))
-    set(v(node_id, 122318L),
+    set(v(nodeId, 122318L),
       v(key, "TMC:cid_58:tabcd_1:Direction"),
       v(value, "positive"))
-    set(v(node_id, 122318L),
+    set(v(nodeId, 122318L),
       v(key, "TMC:cid_58:tabcd_1:LCLversion"),
       v(value, "8.00"))
-    set(v(node_id, 122318L),
+    set(v(nodeId, 122318L),
       v(key, "TMC:cid_58:tabcd_1:LocationCode"),
       v(value, "10696"))
   }
@@ -66,7 +66,7 @@ case class NodesTest() extends FlatSpec
       row(v(id) shouldBe "122318",
         v(occurredAt) shouldBe "2013-06-17 15:49:26Z",
         v(version) shouldBe 6,
-        v(user_id) shouldBe 50299,
+        v(userId) shouldBe 50299,
         v(tags) shouldBe Map(
           "TMC:cid_58:tabcd_1:Direction" -> "positive",
           "TMC:cid_58:tabcd_1:LCLversion" -> "8.00",

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodeTagsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodeTagsTest.scala
@@ -26,13 +26,13 @@ class NodeTagsTest extends FlatSpec
     new NodeTags() with test {
       then()
       numRows shouldBe 10
-      row(v(node_id) shouldBe 122317,
+      row(v(nodeId) shouldBe 122317,
         v(key) shouldBe "TMC:cid_58:tabcd_1:Class",
         v(value) shouldBe "Point")
-      row(v(node_id) shouldBe 122317,
+      row(v(nodeId) shouldBe 122317,
         v(key) shouldBe "TMC:cid_58:tabcd_1:Direction",
         v(value) shouldBe "positive")
-      row(v(node_id) shouldBe 122317,
+      row(v(nodeId) shouldBe 122317,
         v(key) shouldBe "TMC:cid_58:tabcd_1:LCLversion",
         v(value) shouldBe "8.00")
     }

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
@@ -29,19 +29,19 @@ class NodesTest extends FlatSpec
       row(v(id) shouldBe 122317,
         v(tstamp) shouldBe "2014-10-17T13:49:26Z",
         v(version) shouldBe 7,
-        v(user_id) shouldBe 50299,
+        v(userId) shouldBe 50299,
         v(longitude) shouldBe 10.0232716,
         v(latitude) shouldBe 53.5282633)
       row(v(id) shouldBe 122318,
         v(tstamp) shouldBe "2014-10-17T13:49:26Z",
         v(version) shouldBe 6,
-        v(user_id) shouldBe 50299,
+        v(userId) shouldBe 50299,
         v(longitude) shouldBe 10.0243161,
         v(latitude) shouldBe 53.5297589)
       row(v(id) shouldBe 122320,
         v(tstamp) shouldBe "2013-12-20T07:43:33Z",
         v(version) shouldBe 4,
-        v(user_id) shouldBe 51991,
+        v(userId) shouldBe 51991,
         v(longitude) shouldBe 10.0293114,
         v(latitude) shouldBe 53.5351834)
     }


### PR DESCRIPTION
Moved the whole thing to Scala 2.11 and Akka 2.3.14

Some refactoring, more documentation.

Renamed ActionsManagerActor to TransformationManagerActor. Renamed actor messages accordingly. Renamed actions command to transformations.
