### PR TITLE
check JOINs with ONs plus robust hive checksums

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/HiveTransformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/HiveTransformation.scala
@@ -1,34 +1,34 @@
 /**
- * Copyright 2015 Otto (GmbH & Co KG)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright 2015 Otto (GmbH & Co KG)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package org.schedoscope.dsl.transformations
 
-import java.io.{ FileInputStream, InputStream }
+import java.io.{FileInputStream, InputStream}
 
 import org.apache.commons.lang.StringUtils
-import org.apache.hadoop.hive.metastore.api.{ Function, ResourceType, ResourceUri }
+import org.apache.hadoop.hive.metastore.api.{Function, ResourceType, ResourceUri}
 import org.schedoscope.Settings
 import org.schedoscope.dsl.View
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable.{ HashMap, ListBuffer }
+import scala.collection.mutable.{HashMap, ListBuffer}
 
 /**
- * Hive Transformation: compute views via HiveQL Hive Server 2.
- *
- */
+  * Hive Transformation: compute views via HiveQL Hive Server 2.
+  *
+  */
 case class HiveTransformation(sql: String, udfs: List[Function] = List()) extends Transformation {
 
   def name = "hive"
@@ -39,6 +39,7 @@ case class HiveTransformation(sql: String, udfs: List[Function] = List()) extend
   override def stringsToChecksum = List(sql)
 
   description = "[..]" + StringUtils.abbreviate(sql.replaceAll("\n", "").replaceAll("\t", "").replaceAll(".*SELECT", "SELECT").replaceAll("\\s+", " "), 60)
+
 }
 
 object HiveTransformation {
@@ -94,7 +95,8 @@ object HiveTransformation {
     if (partition && view.partitionParameters.nonEmpty) {
       queryPrelude.append("\nPARTITION (")
       queryPrelude.append(view.partitionParameters.tail.foldLeft({
-        val first = view.partitionParameters.head; first.n + " = '" + first.v.get + "'"
+        val first = view.partitionParameters.head;
+        first.n + " = '" + first.v.get + "'"
       }) { (current, parameter) => current + ", " + parameter.n + " = '" + parameter.v.get + "'" })
       queryPrelude.append(")")
     }
@@ -131,4 +133,51 @@ object HiveTransformation {
   def queryFromResource(resourcePath: String): String = queryFrom(getClass().getClassLoader().getResourceAsStream(resourcePath))
 
   def queryFrom(filePath: String): String = queryFrom(new FileInputStream(filePath))
+
+  def normalizeQuery(sql: String): String = {
+    val replaceDQ = HiveTransformation.replaceWhitespacesBetweenChars("\"") _
+    val replaceSQ = HiveTransformation.replaceWhitespacesBetweenChars("'") _
+    val replaceWhitespace = (s: String) => replaceSQ(replaceDQ(s))
+
+    val sqlLines = sql.split("\n")
+
+    val noComments = sqlLines.map {
+      _.trim().replaceAll("^--(.|\\w)+$", "")
+    }.filter(_.nonEmpty).mkString(" ")
+
+    replaceWhitespace(noComments.replaceAll("( |^)[sS][eE][tT] (.|\\t)+?;", ""))
+      .replaceAll("\\s+", " ")
+  }
+
+  def replaceWhitespacesBetweenChars(quote: String)(string: String): String = {
+    val endsWithQuote = string.endsWith(quote) && !string.endsWith("\\" + quote)
+
+    val array = string
+      .split("(?<!\\\\)" + quote)
+
+    if(array.length <= 1) {
+      //no pair of characters nothing to do here
+      return string
+    }
+
+    val replaced = array
+      .zipWithIndex
+      .map { case (s, i) =>
+        //make sure the char has a twin before replacing
+        if (i % 2 == 1 && (i < array.length - 1 || endsWithQuote)) {
+          s.replaceAll("\\s", ";")
+        } else {
+          s
+        }
+      }.mkString(quote)
+
+    //append ending quote if there was one in the input string
+    if (endsWithQuote) {
+      replaced + quote
+    } else {
+      replaced
+    }
+  }
+
+
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/HiveTransformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/HiveTransformation.scala
@@ -31,12 +31,14 @@ import scala.collection.mutable.{HashMap, ListBuffer}
   */
 case class HiveTransformation(sql: String, udfs: List[Function] = List()) extends Transformation {
 
+  import HiveTransformation._
+
   def name = "hive"
 
   override def fileResourcesToChecksum =
     udfs.flatMap(udf => udf.getResourceUris.map(uri => uri.getUri))
 
-  override def stringsToChecksum = List(sql)
+  override def stringsToChecksum = List(normalizeQuery(sql))
 
   description = "[..]" + StringUtils.abbreviate(sql.replaceAll("\n", "").replaceAll("\t", "").replaceAll(".*SELECT", "SELECT").replaceAll("\\s+", " "), 60)
 
@@ -147,6 +149,7 @@ object HiveTransformation {
 
     replaceWhitespace(noComments.replaceAll("( |^)[sS][eE][tT] (.|\\t)+?;", ""))
       .replaceAll("\\s+", " ")
+      .trim
   }
 
   def replaceWhitespacesBetweenChars(quote: String)(string: String): String = {

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
@@ -75,6 +75,12 @@ abstract class Transformation {
    */
   var description = this.toString
 
+  /**
+    * Used to validate the transformation during tests
+    */
+  @throws[InvalidTransformationException]
+  def validateTransformation() = {}
+
 }
 
 /**
@@ -96,3 +102,5 @@ object Transformation {
     }
   }
 }
+
+class InvalidTransformationException(msg: String) extends Throwable(msg)

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -1,27 +1,27 @@
 /**
- * Copyright 2015 Otto (GmbH & Co KG)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright 2015 Otto (GmbH & Co KG)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package org.schedoscope.dsl.transformations
 
 import java.util.Date
 
-import org.scalatest.{ BeforeAndAfter, FlatSpec, Matchers }
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import org.schedoscope.dsl.Parameter.p
-import org.schedoscope.dsl.{ Parameter, Structure, View }
 import org.schedoscope.dsl.transformations.HiveTransformation.queryFromResource
 import org.schedoscope.dsl.transformations.Transformation.replaceParameters
+import org.schedoscope.dsl.{Parameter, Structure, View}
 
 case class Article() extends Structure {
   val name = fieldOf[String]
@@ -131,4 +131,102 @@ FROM STUFF
 WHERE param = 2
 AND anotherParam = 'Value'"""
   }
+
+  "the normalize query function" should "delete comments" in {
+    val qry = "-----23123-xcvo\tn .cvaotrsaooiarst9210132q56`]-[ taroistneaorsitdthdastrtsra\n" +
+      "--a comment\n" +
+//      "--no comment\n" +
+      "select * from coolstuff\n" +
+      "LIMIT 10"
+
+    HiveTransformation.normalizeQuery(qry) shouldBe "select * from coolstuff LIMIT 10"
+  }
+
+  it should "remove whitespaces from the start and end of lines" in {
+    val qry = "   \t\t\t    test \t \n" +
+      "  \t \tte\tst    \n" +
+      "wh at\t   "
+
+    HiveTransformation.normalizeQuery(qry) shouldBe "test te st wh at"
+  }
+
+  it should "remove set commands" in {
+    val qry = "NOSET key=value;\n" +
+      "SET test=hello; \n" +
+    "SELECT;"
+
+    HiveTransformation.normalizeQuery(qry) shouldBe "NOSET key=value; SELECT;"
+  }
+
+  it should "remove duplicate whitespaces" in {
+    val qry1 = "\"this  is\"   a\ttest"
+    val qry2 = "'this  is'   a\ttest"
+    val qry3 = "'  '  '  ' "
+    val qry4 = "'  \\'  '  '  \\'  ' "
+
+    HiveTransformation.normalizeQuery(qry1) shouldBe "\"this;;is\" a test"
+    HiveTransformation.normalizeQuery(qry2) shouldBe "'this;;is' a test"
+    HiveTransformation.normalizeQuery(qry3) shouldBe "';;' ';;'"
+    HiveTransformation.normalizeQuery(qry4) shouldBe "';;\\';;' ';;\\';;'"
+  }
+
+  it should "normalize two queries to be equal" in {
+    val qry1 = "SET memory=1024;\n" +
+      "SET date='20160412';\n" +
+      "\n" +
+      "SELECT \n" +
+      "  price \n" +
+      "FROM \n" +
+      "  transactions\n" +
+      "WHERE\n" +
+      "  date='${date}'"
+
+    val qry2 = "SET memory=2028;\n" +
+      "SET date='20160413';\n" +
+      "\n" +
+      "\n" +
+      "SELECT price \n" +
+      "FROM transactions\n" +
+      "WHERE date='${date}'"
+
+    HiveTransformation.normalizeQuery(qry1) should
+      equal(HiveTransformation.normalizeQuery(qry2))
+  }
+
+  "replace Whitespaces in quotes" should "do it's thing" in {
+    val replaceDQ = HiveTransformation.replaceWhitespacesBetweenChars("\"") _
+    replaceDQ("\"") shouldBe "\""
+    replaceDQ("\"\"") shouldBe "\"\""
+    replaceDQ("test") shouldBe "test"
+    replaceDQ("te\"st") shouldBe "te\"st"
+    replaceDQ("\"  \"") shouldBe "\";;\""
+    replaceDQ("\"  \"\\\"") shouldBe "\";;\"\\\""
+    replaceDQ("\"  \" \" \"") shouldBe "\";;\" \";\""
+    replaceDQ("hi\"  \" \" \"") shouldBe "hi\";;\" \";\""
+    replaceDQ("hi\"  \" test \" \"hi") shouldBe "hi\";;\" test \";\"hi"
+    replaceDQ("\" te\\\"st \"") shouldBe "\";te\\\"st;\""
+    replaceDQ("\" te\\\"st\\\" \"") shouldBe "\";te\\\"st\\\";\""
+    replaceDQ("\" \\\"") shouldBe "\" \\\""
+    replaceDQ("\\\" \"") shouldBe "\\\" \""
+    replaceDQ("\" \\\"s") shouldBe "\" \\\"s"
+    replaceDQ("\\\" \"s") shouldBe "\\\" \"s"
+
+  }
+
+  it should "work when nested" in {
+    val replaceDQ = HiveTransformation.replaceWhitespacesBetweenChars("\"") _
+    val replaceSQ = HiveTransformation.replaceWhitespacesBetweenChars("'") _
+
+    val replace = (s: String) => replaceSQ(replaceDQ(s))
+
+    replace("\"  \"") shouldBe "\";;\""
+    replace("\"  \"\\\"") shouldBe "\";;\"\\\""
+    replace("\"  \" ' '") shouldBe "\";;\" ';'"
+    replace("hi\"  \" \" \"") shouldBe "hi\";;\" \";\""
+    replace("\" \' \" \'") shouldBe "\";';\";'"
+    replace("\" \' \' \"") shouldBe "\";\';\';\""
+    replace("\" \\' \" \\'") shouldBe "\";\\';\" \\'"
+  }
+
+
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -193,6 +193,30 @@ AND anotherParam = 'Value'"""
       equal(HiveTransformation.normalizeQuery(qry2))
   }
 
+  it should "not normalize two different queries to be equal" in {
+    val qry1 = "SET memory=1024;\n" +
+      "SET date='20160412';\n" +
+      "\n" +
+      "SELECT \n" +
+      "  price \n" +
+      "FROM \n" +
+      "  transactions\n" +
+      "WHERE\n" +
+      "  date='${date}'"
+
+    val qry2 = "SET memory=2028;\n" +
+      "SET date='20160413';\n" +
+      "\n" +
+      "\n" +
+      "SELECT price \n" +
+      "FROM transactions\n" +
+    //use '<>' instead of '='
+      "WHERE date<>'${date}'"
+
+    HiveTransformation.normalizeQuery(qry1) should not
+      equal(HiveTransformation.normalizeQuery(qry2))
+  }
+
   "replace Whitespaces in quotes" should "do it's thing" in {
     val replaceDQ = HiveTransformation.replaceWhitespacesBetweenChars("\"") _
     replaceDQ("\"") shouldBe "\""
@@ -262,16 +286,16 @@ AND anotherParam = 'Value'"""
     val qry9 = "SELECT \"join\" on JOIN"
     val qry10 = "SELECT \\\"join\" on JOIN"
 
-    HiveTransformation.compareJoinsOns(qry1) shouldBe true
-    HiveTransformation.compareJoinsOns(qry2) shouldBe true
-    HiveTransformation.compareJoinsOns(qry3) shouldBe true
-    HiveTransformation.compareJoinsOns(qry4) shouldBe true
-    HiveTransformation.compareJoinsOns(qry5) shouldBe false
-    HiveTransformation.compareJoinsOns(qry6) shouldBe false
-    HiveTransformation.compareJoinsOns(qry7) shouldBe false
-    HiveTransformation.compareJoinsOns(qry8) shouldBe true
-    HiveTransformation.compareJoinsOns(qry9) shouldBe true
-    HiveTransformation.compareJoinsOns(qry10) shouldBe false
+    HiveTransformation.checkJoinsWithOns(qry1) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry2) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry3) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry4) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry5) shouldBe false
+    HiveTransformation.checkJoinsWithOns(qry6) shouldBe false
+    HiveTransformation.checkJoinsWithOns(qry7) shouldBe false
+    HiveTransformation.checkJoinsWithOns(qry8) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry9) shouldBe true
+    HiveTransformation.checkJoinsWithOns(qry10) shouldBe false
   }
 
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -250,5 +250,28 @@ AND anotherParam = 'Value'"""
         "select * from prices where id = '12;;23'")
   }
 
+  "Hivetransformation.validateQuery" should "find uneven amount of joins and ons" in {
+    val qry1 = "SELECT JOIN ON TEST"
+    val qry2 = "SELECT join on TEST"
+    val qry3 = "SELECT 'join' on JOIN"
+    val qry4 = "JOIN ON"
+    val qry5 = "ON"
+    val qry6 = "JOIN"
+    val qry7 = "JOIN ON ON"
+    val qry8 = "JOIN JOIN ON ON"
+    val qry9 = "SELECT \"join\" on JOIN"
+    val qry10 = "SELECT \\\"join\" on JOIN"
+
+    HiveTransformation.compareJoinsOns(qry1) shouldBe true
+    HiveTransformation.compareJoinsOns(qry2) shouldBe true
+    HiveTransformation.compareJoinsOns(qry3) shouldBe true
+    HiveTransformation.compareJoinsOns(qry4) shouldBe true
+    HiveTransformation.compareJoinsOns(qry5) shouldBe false
+    HiveTransformation.compareJoinsOns(qry6) shouldBe false
+    HiveTransformation.compareJoinsOns(qry7) shouldBe false
+    HiveTransformation.compareJoinsOns(qry8) shouldBe true
+    HiveTransformation.compareJoinsOns(qry9) shouldBe true
+    HiveTransformation.compareJoinsOns(qry10) shouldBe false
+  }
 
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -135,7 +135,7 @@ AND anotherParam = 'Value'"""
   "the normalize query function" should "delete comments" in {
     val qry = "-----23123-xcvo\tn .cvaotrsaooiarst9210132q56`]-[ taroistneaorsitdthdastrtsra\n" +
       "--a comment\n" +
-//      "--no comment\n" +
+      //      "--no comment\n" +
       "select * from coolstuff\n" +
       "LIMIT 10"
 
@@ -153,7 +153,7 @@ AND anotherParam = 'Value'"""
   it should "remove set commands" in {
     val qry = "NOSET key=value;\n" +
       "SET test=hello; \n" +
-    "SELECT;"
+      "SELECT;"
 
     HiveTransformation.normalizeQuery(qry) shouldBe "NOSET key=value; SELECT;"
   }
@@ -226,6 +226,28 @@ AND anotherParam = 'Value'"""
     replace("\" \' \" \'") shouldBe "\";';\";'"
     replace("\" \' \' \"") shouldBe "\";\';\';\""
     replace("\" \\' \" \\'") shouldBe "\";\\';\" \\'"
+  }
+
+  "Hivetransformation checksum" should "apply the normalize function" in {
+
+    val settings = Map(
+      "memory" -> "12",
+      "date" -> "20160102")
+
+    val orderAll = OrderAll(p(2014), p(10), p(12))
+
+    val hiveTransformation = new HiveTransformation(
+      HiveTransformation.insertInto(
+        orderAll,
+        "select * from\t\nprices  where id = '12  23'",
+        false,
+        settings)
+      , List()
+    )
+
+    hiveTransformation.stringsToChecksum shouldBe
+      List("INSERT OVERWRITE TABLE dev_org_schedoscope_dsl_transformations.order_all " +
+        "select * from prices where id = '12;;23'")
   }
 
 


### PR DESCRIPTION
- Hive queries are now normalized before calculating their checksums.
- JOINS and ONS are now counted and have to be the same during test runs.
- The check can be disabled
