### PR TITLE
Fixed error output during view instantiation

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -439,7 +439,12 @@ object View {
         }
         .map { case ParsedView(env, viewClass, parameters) => newView(viewClass, env, parameters: _*) }
     } catch {
-      case t: Throwable => throw new RuntimeException(s"Error while parsing view(s) ${viewUrlPath} : ${t.getMessage}")
+      case t: Throwable =>
+        if(t.isInstanceOf[java.lang.reflect.InvocationTargetException]) {
+          throw new RuntimeException(s"Error while parsing view(s) ${viewUrlPath} : ${t.getCause().getMessage}")
+        } else {
+          throw new RuntimeException(s"Error while parsing view(s) ${viewUrlPath} : ${t.getMessage}")
+        }
     }
 
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -64,7 +64,8 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
       try {
         viewsFromUrl(viewUrlPath.get)
       } catch {
-        case t: Throwable => throw new IllegalArgumentException(s"Invalid view URL pattern passed: ${viewUrlPath.get}.", t)
+        case t: Throwable => throw new IllegalArgumentException(s"Invalid view URL pattern passed: ${viewUrlPath.get}."
+          + {if(t.getMessage != null) s"\noriginal Message: ${t.getMessage}"},t)
       }
   }
 
@@ -75,7 +76,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
   }
 
   private def commandId(command: Any, args: Seq[Option[String]], start: Option[LocalDateTime] = None) = {
-    val format = DateTimeFormat.forPattern("YYYYMMddHHmmss");
+    val format = DateTimeFormat.forPattern("YYYYMMddHHmmss")
 
     val c = command match {
       case s: String => s

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/DslTest.scala
@@ -24,7 +24,7 @@ import org.schedoscope.dsl.storageformats.{ Parquet, TextFile }
 import org.schedoscope.dsl.transformations.{ HiveTransformation, NoOp }
 import org.schedoscope.dsl.views.{ DailyParameterization, JobMetadata, PointOccurrence }
 import org.schedoscope.schema.ddl.HiveQl.ddl
-import test.eci.datahub.{ AvroView, Brand, Click, ClickOfEC0101, ClickOfEC0101ViaOozie, EdgeCasesView, Product, ProductBrand, ViewWithDefaultParams }
+import test.eci.datahub._
 
 class DslTest extends FlatSpec with Matchers {
 
@@ -340,6 +340,11 @@ class DslTest extends FlatSpec with Matchers {
         dateString should be <= "20140224"
         dateString should be >= "20131202"
     }
+  }
+
+  it should "throw an exception during dynamic instantiation" in {
+    val thrown = the [java.lang.RuntimeException] thrownBy View.viewsFromUrl("dev", "/test.eci.datahub/RequireView/ec0106/")
+    thrown.getMessage() shouldBe "Error while parsing view(s) /test.eci.datahub/RequireView/ec0106/ : requirement failed: Put in upper case: ec0106"
   }
 
   it should "have the same urlPath as the one they were dynamically constructed with" in {

--- a/schedoscope-core/src/test/scala/test/eci/datahub/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/eci/datahub/TestViews.scala
@@ -321,3 +321,14 @@ case class HDFSInputView() extends View with Id {
   storedAs(Parquet())
 }
 
+trait Shop {
+  val shopCode: Parameter[String]
+  require((shopCode.v.get).toUpperCase().equals(shopCode.v.get), "Put in upper case: "+ shopCode.v.get)
+}
+
+case class RequireView(shopCode: Parameter[String])
+  extends View with Shop {
+
+  val field1 = fieldOf[String]
+}
+


### PR DESCRIPTION
The schedoscope shell will no show exception messages thrown during the instantiation of a view.
