### PR TITLE
Overwrite checksum mechanism

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
@@ -31,7 +31,7 @@ abstract class Transformation {
   /**
     * Seed to overwrite checksum
     */
-  var checksumSeed = ""
+  var definedVersion = ""
 
   def getView() = if (view.isDefined) view.get.urlPath else "no-view"
 
@@ -55,10 +55,10 @@ abstract class Transformation {
 
   /**
     * Fluent interface to overwrite checksum calculation.
-    * @param checksumSeed seed to calculate checksum from
+    * @param definedVersion seed to calculate checksum from
     */
-  def overwriteChecksum(checksumSeed: String) = {
-    this.checksumSeed = checksumSeed
+  def defineVersion(definedVersion: String) = {
+    this.definedVersion = definedVersion
     this
   }
 
@@ -76,10 +76,10 @@ abstract class Transformation {
     * Transformation checksum. Per default an MD5 hash of the file resource hashes.
     */
   def checksum = {
-    if (checksumSeed.isEmpty) {
+    if (definedVersion.isEmpty) {
       Checksum.digest((Checksum.resourceHashes(fileResourcesToChecksum) ++ stringsToChecksum): _*)
     } else {
-      Checksum.digest(checksumSeed)
+      Checksum.digest(definedVersion)
     }
   }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
@@ -1,78 +1,99 @@
 /**
- * Copyright 2015 Otto (GmbH & Co KG)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright 2015 Otto (GmbH & Co KG)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package org.schedoscope.dsl.transformations
 
 import org.schedoscope.dsl.View
+
 import scala.collection.mutable.HashMap
 
 /**
- * Base class for transformation types
- */
+  * Base class for transformation types
+  */
 abstract class Transformation {
   /**
-   * View to transformation belongs to
-   */
+    * View to transformation belongs to
+    */
   var view: Option[View] = None
+
+  /**
+    * Seed to overwrite checksum
+    */
+  var checksumSeed = ""
 
   def getView() = if (view.isDefined) view.get.urlPath else "no-view"
 
   /**
-   * Name of the transformation type.
-   */
+    * Name of the transformation type.
+    */
   def name: String
 
   /**
-   * Configuration properties of transformation. Semantics depend on the transformation type. Usually stuff like query placeholders.
-   */
+    * Configuration properties of transformation. Semantics depend on the transformation type. Usually stuff like query placeholders.
+    */
   val configuration = HashMap[String, Any]()
 
   /**
-   * Fluent interface to attach a configuration to a transformation.
-   */
+    * Fluent interface to attach a configuration to a transformation.
+    */
   def configureWith(c: Map[String, Any]) = {
     configuration ++= c
     this
   }
 
   /**
-   * List of file resource paths that influence the transformation checksum of the transformation type.
-   */
+    * Fluent interface to overwrite checksum calculation.
+    * @param checksumSeed seed to calculate checksum from
+    */
+  def overwriteChecksum(checksumSeed: String) = {
+    this.checksumSeed = checksumSeed
+    this
+  }
+
+  /**
+    * List of file resource paths that influence the transformation checksum of the transformation type.
+    */
   def fileResourcesToChecksum = List[String]()
 
   /**
-   * Other checksum influencing strings.
-   */
+    * Other checksum influencing strings.
+    */
   def stringsToChecksum = List[String]()
 
   /**
-   * Transformation checksum. Per default an MD5 hash of the file resource hashes.
-   */
-  lazy val checksum = Checksum.digest((Checksum.resourceHashes(fileResourcesToChecksum) ++ stringsToChecksum): _*)
+    * Transformation checksum. Per default an MD5 hash of the file resource hashes.
+    */
+  def checksum = {
+    if (checksumSeed.isEmpty) {
+      Checksum.digest((Checksum.resourceHashes(fileResourcesToChecksum) ++ stringsToChecksum): _*)
+    } else {
+      Checksum.digest(checksumSeed)
+    }
+  }
 
   /**
-   * Attach a transformation to a view.
-   */
+    * Attach a transformation to a view.
+    */
   def forView(v: View) = {
     view = Some(v)
     this
   }
 
   /**
-   * A textual format for outputting a transformation
-   */
+    * A textual format for outputting a transformation
+    */
   var description = this.toString
 
   /**
@@ -84,9 +105,9 @@ abstract class Transformation {
 }
 
 /**
- * NoOp transformation type. Default transformation which does nothing but checking for
- * the existence of a _SUCCESS flag in the view's fullPath for materialization.
- */
+  * NoOp transformation type. Default transformation which does nothing but checking for
+  * the existence of a _SUCCESS flag in the view's fullPath for materialization.
+  */
 case class NoOp() extends Transformation {
   override def name = "noop"
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Transformation.scala
@@ -54,8 +54,9 @@ abstract class Transformation {
   }
 
   /**
-    * Fluent interface to overwrite checksum calculation.
-    * @param definedVersion seed to calculate checksum from
+    * Fluent interface to define a version for the transformation.
+    * The transformation will now not be invalidated by changes to the logic.
+    * @param definedVersion string with version
     */
   def defineVersion(definedVersion: String) = {
     this.definedVersion = definedVersion

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
@@ -33,6 +33,8 @@ class TransformationTest extends FlatSpec with Matchers {
 
     val checksum3 = transformation.checksum
 
+    checksum1 shouldBe Checksum.digest("select * from view")
+
     checksum1 shouldBe checksum2
 
     checksum3 should not be checksum1

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
@@ -1,0 +1,29 @@
+package org.schedoscope.dsl.transformations
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TransformationTest extends FlatSpec with Matchers {
+
+  "the overwrite checksum mechanism" should "change a checksum" in {
+    //new transformation
+    val transformation = HiveTransformation("select * from view")
+
+    val checksum1 = transformation.checksum
+    //overwrite checksum with the same string as the hiveql
+    transformation.overwriteChecksum("select * from view")
+
+    val checksum2 = transformation.checksum
+
+    //change checksum wiht version
+    transformation.overwriteChecksum("v2.2")
+
+    val checksum3 = transformation.checksum
+
+    checksum1 shouldBe checksum2
+
+    checksum3 should not be checksum1
+    checksum3 should not be checksum2
+
+  }
+
+}

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/TransformationTest.scala
@@ -1,21 +1,35 @@
 package org.schedoscope.dsl.transformations
 
 import org.scalatest.{FlatSpec, Matchers}
+import org.schedoscope.dsl.View
+import org.schedoscope.dsl.transformations.HiveTransformation._
+
+case class HiveView() extends View {
+
+  val f = fieldOf[String]
+
+  transformVia {
+    () => HiveTransformation(
+      insertInto(this, "select * from view"))
+        .defineVersion("v2.2")
+  }
+
+}
 
 class TransformationTest extends FlatSpec with Matchers {
 
-  "the overwrite checksum mechanism" should "change a checksum" in {
+  "the define version method" should "change a checksum" in {
     //new transformation
     val transformation = HiveTransformation("select * from view")
 
     val checksum1 = transformation.checksum
     //overwrite checksum with the same string as the hiveql
-    transformation.overwriteChecksum("select * from view")
+    transformation.defineVersion("select * from view")
 
     val checksum2 = transformation.checksum
 
-    //change checksum wiht version
-    transformation.overwriteChecksum("v2.2")
+    //change checksum with version
+    transformation.defineVersion("v2.2")
 
     val checksum3 = transformation.checksum
 
@@ -25,5 +39,15 @@ class TransformationTest extends FlatSpec with Matchers {
     checksum3 should not be checksum2
 
   }
+
+  it should "change the checksum of a transformation in a view" in {
+    //new transformation
+   val view = new HiveView()
+
+    view.transformation().checksum shouldBe Checksum.digest("v2.2")
+
+  }
+
+
 
 }


### PR DESCRIPTION
The transformation now let's the user define a version which will only invalidate views based on changes of this version. 
