### PR TITLE
Added flag for views which are global during reocurring tests

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/test/LoadableView.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/LoadableView.scala
@@ -35,6 +35,17 @@ trait LoadableView extends WritableView {
   val localResources = ListBuffer.empty[(String, String)]
 
   /**
+    * Fills this view with data from hive, potentially sorted by a column
+    *
+    * @param orderedBy the optional FieldLike for the column to sort by
+    */
+  def populate(orderedBy: Option[FieldLike[_]]) {
+    val db = resources.database
+    rowData.clear()
+    rowData.appendAll(db.selectView(this, orderedBy))
+  }
+
+  /**
     * Adds dependencies for this view
     */
   def basedOn(d: View with WritableView*) {

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/SchedoscopeSpec.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/SchedoscopeSpec.scala
@@ -126,14 +126,18 @@ trait ReusableHiveSchema
       v.resources = resources
     }
 
-    TestUtils.loadView(view, null, false, false)
+    TestUtils.loadView(view,
+      null,
+      disableDependencyCheck = false,
+      disableTransformationValidation = false)
     view.localResources.clear()
 
     rowData.appendAll(view.rowData)
 
-    view.inputFixtures.foreach { v =>
+    view.inputFixtures.filter(!_.isStatic).foreach { v =>
       v.rowData.clear()
     }
+
   }
 
   def v[T](f: Field[T], v: T) = (f, v)

--- a/schedoscope-core/src/main/scala/org/schedoscope/test/WritableView.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/test/WritableView.scala
@@ -32,6 +32,8 @@ trait WritableView extends View {
 
   env = "test"
 
+  val isStatic = false
+
   var resources: TestResources = new LocalTestResources()
 
   val rowData = new ListBuffer[Map[String, Any]]()
@@ -83,17 +85,6 @@ trait WritableView extends View {
     */
   def numRows(): Int = {
     rowData.size
-  }
-
-  /**
-    * Fills this view with data from hive, potentially sorted by a column
-    *
-    * @param orderedBy the optional FieldLike for the column to sort by
-    */
-  def populate(orderedBy: Option[FieldLike[_]]) {
-    val db = resources.database
-    rowData.clear()
-    rowData.appendAll(db.selectView(this, orderedBy))
   }
 
   def createViewTable() {
@@ -148,7 +139,9 @@ object WritableView {
 /**
   * Syntactic sugar for default tests
   */
-trait rows extends WritableView
+trait rows extends WritableView {
+  override val isStatic = true
+}
 
 /**
   * Syntactic sugar for [[ReusableHiveSchema]] tests

--- a/schedoscope-core/src/test/scala/org/schedoscope/test/TestSchedoscopeSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/test/TestSchedoscopeSpec.scala
@@ -60,13 +60,28 @@ class TestSchedoscopeSpec extends SchedoscopeSpec {
   }
 
   it should "load the local resource into hfds" in {
-    val fs = resources.fileSystem
-    val target = new Path(s"${resources.remoteTestDirectory}/test.sql")
+    val fs = click.resources.fileSystem
+    val target = new Path(s"${click.resources.remoteTestDirectory}/test.sql")
     fs.exists(target) shouldBe true
   }
 }
 
 class TestReusableFixtures extends SchedoscopeSpec with ReusableHiveSchema {
+
+  val ec0101static = new Click(p("EC0101"), p("2014"), p("01"), p("01")) with rows {
+    set(
+      v(id, "01"),
+      v(url, "url1"))
+    set(
+      v(id, "02"),
+      v(url, "url2"))
+    set(
+      v(id, "03"),
+      v(url, "url3"))
+    set(
+      v(id, "04"),
+      v(url, "url4"))
+  }
 
   val ec0101Clicks = new Click(p("EC0101"), p("2014"), p("01"), p("01")) with InputSchema
 
@@ -74,6 +89,11 @@ class TestReusableFixtures extends SchedoscopeSpec with ReusableHiveSchema {
 
   val click = new ClickOfEC0101(p("2014"), p("01"), p("01")) with OutputSchema {
     basedOn(ec0101Clicks, ec0106Clicks)
+    withResource("test" -> "src/test/resources/test.sql")
+  }
+
+  val click2 = new ClickOfEC0101(p("2014"), p("01"), p("01")) with OutputSchema {
+    basedOn(ec0101static)
     withResource("test" -> "src/test/resources/test.sql")
   }
 
@@ -109,6 +129,7 @@ class TestReusableFixtures extends SchedoscopeSpec with ReusableHiveSchema {
   }
 
   it should "do this" in {
+
     {
       import ec0101Clicks._
       set(
@@ -125,6 +146,25 @@ class TestReusableFixtures extends SchedoscopeSpec with ReusableHiveSchema {
     row(v(id) shouldBe "event01",
       v(url) shouldBe "url1")
     row(v(id) shouldBe "event02",
+      v(url) shouldBe "url2")
+
+  }
+
+  it should "handle tests with static input views" in {
+    then(click2)
+    numRows() shouldBe 4
+    row(v(id) shouldBe "01",
+      v(url) shouldBe "url1")
+    row(v(id) shouldBe "02",
+      v(url) shouldBe "url2")
+  }
+
+  it should "handle recurring tests with static input views" in {
+    then(click2)
+    numRows() shouldBe 4
+    row(v(id) shouldBe "01",
+      v(url) shouldBe "url1")
+    row(v(id) shouldBe "02",
       v(url) shouldBe "url2")
   }
 

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
@@ -20,7 +20,7 @@ import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class RestaurantsTest() extends SchedoscopeSpec {
+class RestaurantsTest extends SchedoscopeSpec {
 
   val nodes = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "267622930"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/RestaurantsTest.scala
@@ -15,14 +15,12 @@
   */
 package schedoscope.example.osm.datahub
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.schedoscope.dsl.Field._
 import org.schedoscope.dsl.Parameter.p
-import org.schedoscope.test.{rows, test}
+import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class RestaurantsTest() extends FlatSpec
-  with Matchers {
+case class RestaurantsTest() extends SchedoscopeSpec {
 
   val nodes = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "267622930"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
@@ -15,14 +15,12 @@
   */
 package schedoscope.example.osm.datahub
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.schedoscope.dsl.Field._
 import org.schedoscope.dsl.Parameter.p
-import org.schedoscope.test.{rows, test}
+import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class ShopsTest() extends FlatSpec
-  with Matchers {
+case class ShopsTest() extends SchedoscopeSpec {
 
   val nodes = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "122317"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/ShopsTest.scala
@@ -20,7 +20,7 @@ import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class ShopsTest() extends SchedoscopeSpec {
+class ShopsTest extends SchedoscopeSpec {
 
   val nodes = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "122317"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
@@ -15,14 +15,12 @@
   */
 package schedoscope.example.osm.datahub
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.schedoscope.dsl.Field._
 import org.schedoscope.dsl.Parameter.p
-import org.schedoscope.test.{rows, test}
+import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class TrainstationsTest() extends FlatSpec
-  with Matchers {
+case class TrainstationsTest() extends SchedoscopeSpec {
 
   val nodesInput = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "122317"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datahub/TrainstationsTest.scala
@@ -20,7 +20,7 @@ import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.processed.Nodes
 
-case class TrainstationsTest() extends SchedoscopeSpec {
+class TrainstationsTest extends SchedoscopeSpec {
 
   val nodesInput = new Nodes(p("2014"), p("09")) with rows {
     set(v(id, "122317"),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datamart/ShopProfilesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/datamart/ShopProfilesTest.scala
@@ -21,7 +21,7 @@ import org.schedoscope.dsl.Field._
 import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.datahub.{Restaurants, Shops, Trainstations}
 
-case class ShopProfilesTest() extends SchedoscopeSpec {
+class ShopProfilesTest extends SchedoscopeSpec {
 
   Class.forName("org.apache.derby.jdbc.EmbeddedDriver")
   val dbConnection = DriverManager.getConnection("jdbc:derby:memory:TestingDB;create=true")

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
@@ -15,14 +15,12 @@
   */
 package schedoscope.example.osm.processed
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.schedoscope.dsl.Field._
 import org.schedoscope.dsl.Parameter.p
-import org.schedoscope.test.{rows, test}
+import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.stage.NodeTags
 
-case class NodesTest() extends FlatSpec
-  with Matchers {
+case class NodesTest() extends SchedoscopeSpec {
 
   val nodes = new NodesWithGeohash() with rows {
     set(v(id, 122317L),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesTest.scala
@@ -20,7 +20,7 @@ import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 import schedoscope.example.osm.stage.NodeTags
 
-case class NodesTest() extends SchedoscopeSpec {
+class NodesTest extends SchedoscopeSpec {
 
   val nodes = new NodesWithGeohash() with rows {
     set(v(id, 122317L),

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesWithGeohashTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/processed/NodesWithGeohashTest.scala
@@ -15,11 +15,10 @@
   */
 package schedoscope.example.osm.processed
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.schedoscope.dsl.Field._
-import org.schedoscope.test.{rows, test}
+import org.schedoscope.test.{SchedoscopeSpec, rows, test}
 
-class NodesWithGeohashTest extends FlatSpec with Matchers {
+class NodesWithGeohashTest extends SchedoscopeSpec {
 
   val stageNodesInput = new schedoscope.example.osm.stage.Nodes() with rows {
     set(

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodeTagsTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodeTagsTest.scala
@@ -15,11 +15,9 @@
   */
 package schedoscope.example.osm.stage
 
-import org.scalatest.{FlatSpec, Matchers}
-import org.schedoscope.test.test
+import org.schedoscope.test.{SchedoscopeSpec, test}
 
-class NodeTagsTest extends FlatSpec
-  with Matchers {
+class NodeTagsTest extends SchedoscopeSpec {
 
   "stage.NodeTags" should "load correctly from file" in {
     new NodeTags() with test {

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
@@ -36,7 +36,7 @@ class NodesTest extends SchedoscopeSpec {
       v(latitude) shouldBe 53.5282633)
   }
 
-  "stage.Nodes" should "load the second node" in {
+  it should "load the second node" in {
     startWithRow(1)
     row(v(id) shouldBe 122318,
       v(tstamp) shouldBe "2014-10-17T13:49:26Z",
@@ -46,7 +46,7 @@ class NodesTest extends SchedoscopeSpec {
       v(latitude) shouldBe 53.5297589)
   }
 
-  "stage.Nodes" should "load the third node" in {
+  it should "load the third node" in {
     startWithRow(2)
     row(v(id) shouldBe 122320,
       v(tstamp) shouldBe "2013-12-20T07:43:33Z",

--- a/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
+++ b/schedoscope-tutorial/src/test/scala/schedoscope/example/osm/stage/NodesTest.scala
@@ -15,34 +15,44 @@
   */
 package schedoscope.example.osm.stage
 
-import org.scalatest.{FlatSpec, Matchers}
-import org.schedoscope.test.test
+import org.schedoscope.test.{SchedoscopeSpec, test}
 
-class NodesTest extends FlatSpec
-  with Matchers {
+class NodesTest extends SchedoscopeSpec {
+
+  val nodes = putViewUnderTest(new Nodes with test)
+
+  import nodes._
 
   "stage.Nodes" should "load correctly from classpath" in {
-    new Nodes() with test {
-      then()
-      numRows shouldBe 10
-      row(v(id) shouldBe 122317,
-        v(tstamp) shouldBe "2014-10-17T13:49:26Z",
-        v(version) shouldBe 7,
-        v(userId) shouldBe 50299,
-        v(longitude) shouldBe 10.0232716,
-        v(latitude) shouldBe 53.5282633)
-      row(v(id) shouldBe 122318,
-        v(tstamp) shouldBe "2014-10-17T13:49:26Z",
-        v(version) shouldBe 6,
-        v(userId) shouldBe 50299,
-        v(longitude) shouldBe 10.0243161,
-        v(latitude) shouldBe 53.5297589)
-      row(v(id) shouldBe 122320,
-        v(tstamp) shouldBe "2013-12-20T07:43:33Z",
-        v(version) shouldBe 4,
-        v(userId) shouldBe 51991,
-        v(longitude) shouldBe 10.0293114,
-        v(latitude) shouldBe 53.5351834)
-    }
+    numRows shouldBe 10
+  }
+
+  "stage.Nodes" should "load the first node" in {
+    row(v(id) shouldBe 122317,
+      v(tstamp) shouldBe "2014-10-17T13:49:26Z",
+      v(version) shouldBe 7,
+      v(userId) shouldBe 50299,
+      v(longitude) shouldBe 10.0232716,
+      v(latitude) shouldBe 53.5282633)
+  }
+
+  "stage.Nodes" should "load the second node" in {
+    startWithRow(1)
+    row(v(id) shouldBe 122318,
+      v(tstamp) shouldBe "2014-10-17T13:49:26Z",
+      v(version) shouldBe 6,
+      v(userId) shouldBe 50299,
+      v(longitude) shouldBe 10.0243161,
+      v(latitude) shouldBe 53.5297589)
+  }
+
+  "stage.Nodes" should "load the third node" in {
+    startWithRow(2)
+    row(v(id) shouldBe 122320,
+      v(tstamp) shouldBe "2013-12-20T07:43:33Z",
+      v(version) shouldBe 4,
+      v(userId) shouldBe 51991,
+      v(longitude) shouldBe 10.0293114,
+      v(latitude) shouldBe 53.5351834)
   }
 }


### PR DESCRIPTION
When using the ReusableHiveSchema trait globally definined views with input have been deleted after the first run. This fixes the fault by adding a flag which marks global input views.
