### PR TITLE
Make with errors flag visible with external views

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -185,7 +185,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   }
 
   /**
-    * Checks wether a given parameter is implemented using a table name suffix.
+    * Checks whether a given parameter is implemented using a table name suffix.
     */
   def isSuffixPartition(p: Parameter[_]) = suffixPartitions.contains(p)
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewActor.scala
@@ -157,7 +157,13 @@ class ViewActor(var currentState: ViewSchedulingState, settings: SchedoscopeSett
   def stateChange(currentState: ViewSchedulingState, updatedState: ViewSchedulingState) = currentState.getClass != updatedState.getClass
 
   def logStateChange(newState: ViewSchedulingState, previousState: ViewSchedulingState) {
-    viewManagerActor ! ViewStatusResponse(newState.label, newState.view, self)
+    newState match {
+      case vss: Transforming => viewManagerActor ! ViewStatusResponse(vss.label, newState.view, self, Some(vss.withErrors), Some(vss.incomplete) )
+      case vss: Materialized => viewManagerActor ! ViewStatusResponse(vss.label, newState.view, self, Some(vss.withErrors), Some(vss.incomplete) )
+      case vss: Retrying => viewManagerActor ! ViewStatusResponse(vss.label, newState.view, self, Some(vss.withErrors), Some(vss.incomplete) )
+      case _ => viewManagerActor ! ViewStatusResponse(newState.label, newState.view, self)
+    }
+
 
     log.info(s"VIEWACTOR STATE CHANGE ===> ${newState.label.toUpperCase()}: newState=${newState} previousState=${previousState}")
   }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
@@ -35,7 +35,7 @@ import scala.collection.mutable.{HashMap, HashSet}
   * the last transformation timestamps and version checksums from the metastore for already materialized
   * views.
   *
-  * It does this by cooperating with the parition creator actor and metadata logger actor.
+  * It does this by cooperating with the partition creator actor and metadata logger actor.
   */
 class ViewManagerActor(settings: SchedoscopeSettings, actionsManagerActor: ActorRef, partitionCreatorActor: ActorRef, metadataLoggerActor: ActorRef) extends Actor {
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliDataFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliDataFormat.scala
@@ -23,6 +23,12 @@ import scala.concurrent.Future
 object SchedoscopeCliFormat {
   // FIXME: a more generic parsing would be cool...
 
+  private def formatMap(p: Option[Map[String, String]]) =
+    if (p.isDefined) {
+      p.get.foldLeft("") { (s: String, pair: (String, String)) =>
+        s + ", " + pair._1 + "=" + pair._2 }
+    } else ""
+
   def serialize(o: Any): String = {
     val sb = new StringBuilder()
     o match {
@@ -36,11 +42,7 @@ object SchedoscopeCliFormat {
               } else {
                 ("", "", "")
               }
-            val props = if (p.properties.isDefined) {
-              p.properties.get.foldLeft("") { (s: String, pair: (String, String)) =>
-                s + ", " + pair._1 + "=" + pair._2 }
-            } else ""
-            Array(p.actor, p.status, s, d, t, props)
+            Array(p.actor, p.status, s, d, t, formatMap(p.properties))
           }).toArray
           sb.append(ASCIITable.getInstance.getTable(header, running))
           sb.append(s"Total: ${running.size}\n")
@@ -51,13 +53,9 @@ object SchedoscopeCliFormat {
       case qs: QueueStatusList => {
         if (qs.queues.flatMap(q => q._2).size > 0) {
           val header = Array("TYP", "DESC", "TARGET_VIEW", "PROPS")
-          val queued = qs.queues.flatMap(q => q._2.map(e => {
-            val props = if (e.properties.isDefined) {
-              e.properties.get.foldLeft("") { (s: String, pair: (String, String)) =>
-                s + ", " + pair._1 + "=" + pair._2 }
-            } else ""
-            Array(q._1, e.description, e.targetView, props)
-          })).toArray
+          val queued = qs.queues.flatMap(q => q._2.map(e =>
+            Array(q._1, e.description, e.targetView, formatMap(e.properties))
+          )).toArray
           sb.append(ASCIITable.getInstance.getTable(header, queued))
           sb.append(s"Total: ${queued.size}")
         }
@@ -77,20 +75,13 @@ object SchedoscopeCliFormat {
 
           val data = vl.views
             .filter(!_.isTable.getOrElse(false))
-            .map(d => {
-
-              val props = if (d.properties.isDefined) {
-                d.properties.get.foldLeft("") { (s: String, pair: (String, String)) =>
-                  s + ", " + pair._1 + "=" + pair._2 }
-              } else ""
-
-              Array(d.viewPath, d.status,
+            .map(d => Array(d.viewPath, d.status,
                 if (d.viewTableName.isDefined && fields.get(d.viewTableName.get).isDefined) {
                   fields.get(d.viewTableName.get).get.map(fieldStatus =>
                     fieldStatus.name + "::" + fieldStatus.fieldtype).mkString(", ") +
-                    " " + props
-                } else props )
-            }).toArray
+                    " " + formatMap(d.properties)
+                } else formatMap(d.properties) )
+            ).toArray
 
           sb.append(ASCIITable.getInstance.getTable(header, data))
           sb.append(s"Total: ${data.size}\n")

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
@@ -207,8 +207,10 @@ case class TransformationStatusResponse[T <: Transformation](val message: String
   * @param status textual description of the status
   * @param view   reference to the curresponding view
   * @param actor  actor reference to ViewActor
+  * @param errors true if some transformations in that subtree have been failing
+  * @param incomplete true of not all transitive dependencies had data available
   */
-case class ViewStatusResponse(val status: String, view: View, actor: ActorRef) extends CommandResponse
+case class ViewStatusResponse(val status: String, view: View, actor: ActorRef, errors: Option[Boolean]=None, incomplete:Option[Boolean]=None) extends CommandResponse
 
 /**
   * Schema actor returning the stored transformation metadata (version checksum, timestamp) retrieved from metadata store

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -97,10 +97,15 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
   private def viewStatusBuilder(vsr: ViewStatusResponse,
                                 viewTableName:Option[String],
                                 isTable:Option[Boolean],
-                                properties: Option[Map[String, String]],
                                 dependencies: Option[Boolean],
                                 overview:Boolean=true,
                                 all:Option[Boolean]) = {
+    val properties =
+      if (vsr.errors.isDefined || vsr.incomplete.isDefined)
+        Some(Map("errors" -> vsr.errors.getOrElse(false).toString,
+          "incomplete" -> vsr.incomplete.getOrElse(false).toString))
+      else None
+
     ViewStatus(
       viewPath = vsr.view.urlPath,
       viewTableName = viewTableName,
@@ -129,7 +134,6 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
       viewStatusBuilder(vsr = v
         , viewTableName = if (all.getOrElse(false)) Some(v.view.tableName) else None
         , isTable = if (all.getOrElse(false)) Some(false) else None
-        , properties = None
         , dependencies = dependencies
         , overview =  true
         , all = all
@@ -144,11 +148,9 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
           viewStatusBuilder(vsr = v
             , viewTableName = Option(v.view.tableName)
             , isTable = Option(true)
-            , properties = Some(Map("errors" -> v.errors.getOrElse(false).toString,
-              "incomplete" -> v.incomplete.getOrElse(false).toString))
             , dependencies = dependencies
             , overview = false
-            , all
+            , all = all
           )
         )
         .toList ::: viewStatusListWithoutViewDetails

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -155,7 +155,10 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
             , isTable = Option(true)
             , properties = Some(Map("errors" -> v.errors.getOrElse(false).toString,
               "incomplete" -> v.incomplete.getOrElse(false).toString))
-            , dependencies = None
+            , dependencies = if ((dependencies.getOrElse(false) || all.getOrElse(false)) && !v.view.dependencies.isEmpty)
+              Some(v.view.dependencies.map(d => (d.tableName, d.urlPath)).groupBy(_._1).mapValues(_.toList.map(_._2)))
+            else
+              None
             , overview = false
           )
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -99,8 +99,9 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
                                 viewTableName:Option[String],
                                 isTable:Option[Boolean],
                                 properties: Option[Map[String, String]],
-                                dependencies: Option[Map[String, List[String]]],
-                                overview:Boolean=true) = {
+                                dependencies: Option[Boolean],
+                                overview:Boolean=true,
+                                all:Option[Boolean]) = {
     ViewStatus(
       viewPath = vsr.view.urlPath,
       viewTableName = viewTableName,
@@ -109,7 +110,10 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
       fields = if(overview) None else Option(vsr.view.fields.map(f => FieldStatus(f.n, HiveQl.typeDdl(f.t), f.comment)).toList),
       parameters = if(overview || vsr.view.parameters.isEmpty) None else
         Some(vsr.view.parameters.map(p => FieldStatus(p.n, p.t.runtimeClass.getSimpleName, None)).toList),
-      dependencies = dependencies,
+      dependencies = if ((dependencies.getOrElse(false) || all.getOrElse(false)) && !vsr.view.dependencies.isEmpty)
+        Some(vsr.view.dependencies.map(d => (d.tableName, d.urlPath)).groupBy(_._1).mapValues(_.toList.map(_._2)))
+      else
+        None,
       transformation = if(overview) None else Option(vsr.view.registeredTransformation().viewTransformationStatus),
       export = if(overview) None else Option(viewExportStatus(vsr.view.registeredExports.map(e => e.apply()))),
       storageFormat = if(overview) None else Option(vsr.view.storageFormat.getClass.getSimpleName),
@@ -127,11 +131,9 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
         , viewTableName = if (all.getOrElse(false)) Some(v.view.tableName) else None
         , isTable = if (all.getOrElse(false)) Some(false) else None
         , properties = None
-        , dependencies = if ((dependencies.getOrElse(false) || all.getOrElse(false)) && !v.view.dependencies.isEmpty)
-          Some(v.view.dependencies.map(d => (d.tableName, d.urlPath)).groupBy(_._1).mapValues(_.toList.map(_._2)))
-        else
-          None
+        , dependencies = dependencies
         , overview =  true
+        , all = all
       )
     }
 
@@ -145,11 +147,9 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
             , isTable = Option(true)
             , properties = Some(Map("errors" -> v.errors.getOrElse(false).toString,
               "incomplete" -> v.incomplete.getOrElse(false).toString))
-            , dependencies = if ((dependencies.getOrElse(false) || all.getOrElse(false)) && !v.view.dependencies.isEmpty)
-              Some(v.view.dependencies.map(d => (d.tableName, d.urlPath)).groupBy(_._1).mapValues(_.toList.map(_._2)))
-            else
-              None
+            , dependencies = dependencies
             , overview = false
+            , all
           )
         )
         .toList ::: viewStatusListWithoutViewDetails

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -104,7 +104,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
 
   private def viewStatusListFromStatusResponses(viewStatusResponses: List[ViewStatusResponse], dependencies: Option[Boolean], overview: Option[Boolean], all: Option[Boolean]) = {
 
-    lazy val viewStatusListWithoutViewDetails = viewStatusResponses.map { v =>
+    val viewStatusListWithoutViewDetails = viewStatusResponses.map { v =>
       viewStatusBuilder(vsr = v
         , viewTableName = if (all.getOrElse(false)) Some(v.view.tableName) else None
         , isTable = if (all.getOrElse(false)) Some(false) else None


### PR DESCRIPTION
PR goal:
Popagate/extend ViewStatus information withErrors && incomplete params (in case they are present in the ViewSchedulingState) to ViewStatusResponses, so that information may be displayed to end user 

PR summary:
- Added 2 optional params (withErrors, incomplete) to ViewStatusResponse case class;
- Made sure ViewActor adds this information when replying to ViewManagerActor
- Refactor the way ViewStatus are built in generic SchedoscopeServiceImpl
- Formatted displaying in CLI