### PR TITLE
Enable putting table properties in view

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -121,8 +121,9 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
 
   var tblProperties = HashMap[String, String]()
 
-  var inOutputformat = HashMap[String, String]("input" -> "org.apache.hadoop.mapred.SequenceFileInputFormat",
-    "output" -> "org.apache.hadoop.mapred.SequenceFileOutputFormat")
+  var inOutputformat = HashMap[String, String](
+    "input" -> "org.apache.hadoop.mapred.TextInputFormat",
+    "output" -> "org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat")
   var serDe: Option[String] = None
   var serDeProperties = HashMap[String, String]()
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -268,7 +268,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
           Map("input" -> "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
             "output" -> "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"))
 
-        setTblProperties(Map("avro.schema.url" -> s"${avroSchemaPathPrefix}/${schemaPath}"))
+        tblProperties(Map("avro.schema.url" -> s"${avroSchemaPathPrefix}/${schemaPath}"))
 
       case OptimizedRowColumnar() =>
         setInOutputformat(
@@ -327,7 +327,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   /**
     * Specify table properties of a view, which is implemented in Hive as clause TBLPROPERTIES
     */
-  def setTblProperties(m: Map[String, String]):Unit = tblProperties ++= m
+  def tblProperties(m: Map[String, String]):Unit = tblProperties ++= m
 
   /**
     * Specify custom SerDe

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -108,6 +108,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   var registeredTransformation: () => Transformation = () => NoOp()
   var registeredExports: List[() => Transformation] = List()
   var isMaterializeOnce = false
+  var tblProperties = scala.collection.mutable.HashMap[String, String]()
 
   override def toString() = urlPath
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -108,7 +108,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
   var registeredTransformation: () => Transformation = () => NoOp()
   var registeredExports: List[() => Transformation] = List()
   var isMaterializeOnce = false
-  var tblProperties = scala.collection.mutable.HashMap[String, String]()
+  var tblProperties = Map[String, String]()
 
   override def toString() = urlPath
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -318,8 +318,8 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
 
       case RecordColumnarFile() =>
         setInOutputformat(
-          Map("input" -> "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
-            "output" -> "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"))
+          Map("input" -> "org.apache.hadoop.hive.ql.io.RCFileInputFormat",
+            "output" -> "org.apache.hadoop.hive.ql.io.RCFileOutputFormat"))
     }
 
   }

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -230,6 +230,11 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
     this.additionalStoragePathSuffix = Option(additionalStoragePathSuffix)
   }
 
+  def tblProperties(tblProps: Map[String, String]) =
+    tblProperties = tblProps
+
+
+
   /**
     * Postfactum configuration of the registered transformation. Useful to override transformation configs within a test.
     */

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -253,9 +253,6 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
         s3UriScheme = Some(uriScheme)
         storedAs(storageFormat, additionalStoragePathPrefix, additionalStoragePathSuffix)
 
-      case Avro(schemaPath, _) =>
-        tblProperties(Map("avro.schema.url" -> s"${avroSchemaPathPrefix}/${schemaPath}"))
-
       case _ =>
         // do nothing ..
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -267,17 +267,14 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
           Map("input" -> "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
             "output" -> "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"))
 
-        // TODO: confirm if nice to have
         setTblProperties(Map("avro.schema.url" -> s"${avroSchemaPathPrefix}/${schemaPath}"))
 
       case OptimizedRowColumnar() =>
-        rowFormat("org.apache.hadoop.hive.ql.io.orc.OrcSerde")
         setInOutputformat(
           Map("input" -> "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
             "output" -> "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"))
 
       case Parquet() =>
-        rowFormat("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
         setInOutputformat(
           Map("input" -> "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
             "output" -> "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"))

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
@@ -118,6 +118,13 @@ case class TextFile(fieldTerminator: String = null, collectionItemTerminator: St
   *
   * @param serDe                  custom SerDe
   * @param serDeProperties        specify optionally SERDEPROPERTIES
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS TEXTFILE,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
   *
   */
 case class Json(serDe: String = "org.apache.hive.hcatalog.data.JsonSerDe", serDeProperties: Map[String, String] = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
@@ -130,6 +137,13 @@ case class Json(serDe: String = "org.apache.hive.hcatalog.data.JsonSerDe", serDe
   *
   * @param serDe                  custom SerDe
   * @param serDeProperties        specify optionally SERDEPROPERTIES
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS TEXTFILE,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
   * Note: valid for both Comma/Tab Separated (CSV/TSV) formats
   */
 case class Csv(serDe: String = "org.apache.hadoop.hive.serde2.OpenCSVSerde", serDeProperties: Map[String, String] = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
@@ -22,26 +22,59 @@ abstract sealed class StorageFormat
 
 /**
   * Store a view's data as Parquet
+  *
+  * @param fullRowFormatCreateTblStmt instead of using STORED AS PARQUET,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
   */
-case class Parquet() extends StorageFormat
+case class Parquet(fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Store a view's data as Avro
   *
-  * @param schemaPath storage location of Avro schema
+  * @param schemaPath                 storage location of Avro schema
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS AVRO,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
   *
   */
-case class Avro(schemaPath: String) extends StorageFormat
+case class Avro(schemaPath: String, fullRowFormatCreateTblStmt:Boolean=true) extends StorageFormat
 
 /**
   * Store a view's data as ORC
+  *
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS ORC,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
   */
-case class OptimizedRowColumnar() extends StorageFormat
+case class OptimizedRowColumnar(fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Store a view's data as RCFile
+  *
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS RCFILE,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.hive.ql.io.RCFileInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.RCFileOutputFormat'
   */
-case class RecordColumnarFile() extends StorageFormat
+case class RecordColumnarFile(fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Store a view's data as SequenceFile
@@ -49,8 +82,15 @@ case class RecordColumnarFile() extends StorageFormat
   * @param collectionItemTerminator separator for items in collections, default is \002
   * @param mapKeyTerminator         char for separating map keys and values, default is \003
   * @param lineTerminator           default is \n
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS SEQUENCEFILE,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.mapred.SequenceFileInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.mapred.SequenceFileOutputFormat'
   */
-case class SequenceFile(val fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null) extends StorageFormat
+case class SequenceFile(fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Store a view's data as a Hive textfile (default)
@@ -59,31 +99,40 @@ case class SequenceFile(val fieldTerminator: String = null, collectionItemTermin
   * @param collectionItemTerminator separator for items in collections, default is \002
   * @param mapKeyTerminator         char for separating map keys and values, default is \003
   * @param lineTerminator           default is \n
+  * @param serDe                    custom or native SerDe
+  * @param serDeProperties        specify optionally SERDEPROPERTIES
+  * @param fullRowFormatCreateTblStmt for hive versions prior to 0.13,
+  *                                   instead of using STORED AS TEXTFILE,
+  *                                   expands CREATE TABLE with hive
+  *                                   with:
+  *                                   STORED AS
+  *                                             INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+  *                                             OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
   */
-case class TextFile(val fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null) extends StorageFormat
-
-/**
-  * Convenience case class to store a view's data
-  * as TextFile, but automatically setting ROW FORMAT SERDE
-  * RegexSerde and SERDEPROPERTIES
-  */
-case class TextfileWithRegEx(inputRegex: String) extends StorageFormat
+case class TextFile(fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null, serDe: String = null, serDeProperties: Map[String, String] = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Convenience case class to store a view's data
   * as TextFile, but automatically setting ROW FORMAT SERDE
   * JsonSerDe
+  *
+  * @param serDe                  custom SerDe
+  * @param serDeProperties        specify optionally SERDEPROPERTIES
+  *
   */
-case class Json() extends StorageFormat
+case class Json(serDe: String = "org.apache.hive.hcatalog.data.JsonSerDe", serDeProperties: Map[String, String] = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 
 /**
   * Convenience case class to store a view's data
   * as TextFile, but automatically setting ROW FORMAT SERDE
   * OpenCSVSerde
+  *
+  * @param serDe                  custom SerDe
+  * @param serDeProperties        specify optionally SERDEPROPERTIES
   * Note: valid for both Comma/Tab Separated (CSV/TSV) formats
   */
-case class Csv() extends StorageFormat
+case class Csv(serDe: String = "org.apache.hadoop.hive.serde2.OpenCSVSerde", serDeProperties: Map[String, String] = null, fullRowFormatCreateTblStmt:Boolean=false) extends StorageFormat
 
 /**
   * Generic input Output specifier
@@ -96,8 +145,13 @@ case class Csv() extends StorageFormat
   * is also present
   *
   * Example use case: LZO compression
+  *
+  * @param input                  custom INPUTFORMAT
+  * @param output                 custom OUTPUTFORMAT
+  * @param serDe                  custom SerDe
+  * @param serDeProperties        specify optionally SERDEPROPERTIES
   */
-case class InOutputFormat(input: String, output: String, serDe: Option[String] = None) extends StorageFormat
+case class InOutputFormat(input: String, output: String, serDe: String = null, serDeProperties: Map[String, String] = null) extends StorageFormat
 
 
 /**

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
@@ -98,3 +98,17 @@ case class Csv() extends StorageFormat
   * Example use case: LZO compression
   */
 case class InOutputFormat(input: String, output: String, serDe: Option[String] = None) extends StorageFormat
+
+
+/**
+  * Convenience case class to store a view's data
+  * as any Storage Format, but automatically setting
+  * LOCATION 'S3-Bucket'
+  *
+  * @param bucketName     the unique AWS S3 bucket name
+  * @param storageFormat  the type of files to use (e.g. parquet/avro/textFile ...)
+  * @param uriScheme      URI scheme associated with hadoop version used, as well AWS region;
+  *                       with default value "s3n"; for more information, please check
+  *                       https://wiki.apache.org/hadoop/AmazonS3
+  */
+case class S3(bucketName: String, storageFormat: StorageFormat, uriScheme: String = "s3n") extends StorageFormat

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/storageformats/StorageFormat.scala
@@ -21,18 +21,7 @@ package org.schedoscope.dsl.storageformats
 abstract sealed class StorageFormat
 
 /**
-  * Store a view's data as a Hive textfile (default)
-  *
-  * @param fieldTerminator          separator for fields, default is \001
-  * @param collectionItemTerminator separator for items in collections, default is \002
-  * @param mapKeyTerminator         char for separating map keys and values, default is \003
-  * @param lineTerminator           default is \n
-  */
-case class TextFile(val fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null) extends StorageFormat
-
-/**
   * Store a view's data as Parquet
-  *
   */
 case class Parquet() extends StorageFormat
 
@@ -43,3 +32,69 @@ case class Parquet() extends StorageFormat
   *
   */
 case class Avro(schemaPath: String) extends StorageFormat
+
+/**
+  * Store a view's data as ORC
+  */
+case class OptimizedRowColumnar() extends StorageFormat
+
+/**
+  * Store a view's data as RCFile
+  */
+case class RecordColumnarFile() extends StorageFormat
+
+/**
+  * Store a view's data as SequenceFile
+  * @param fieldTerminator          separator for fields, default is \001
+  * @param collectionItemTerminator separator for items in collections, default is \002
+  * @param mapKeyTerminator         char for separating map keys and values, default is \003
+  * @param lineTerminator           default is \n
+  */
+case class SequenceFile(val fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null) extends StorageFormat
+
+/**
+  * Store a view's data as a Hive textfile (default)
+  *
+  * @param fieldTerminator          separator for fields, default is \001
+  * @param collectionItemTerminator separator for items in collections, default is \002
+  * @param mapKeyTerminator         char for separating map keys and values, default is \003
+  * @param lineTerminator           default is \n
+  */
+case class TextFile(val fieldTerminator: String = null, collectionItemTerminator: String = null, mapKeyTerminator: String = null, lineTerminator: String = null) extends StorageFormat
+
+/**
+  * Convenience case class to store a view's data
+  * as TextFile, but automatically setting ROW FORMAT SERDE
+  * RegexSerde and SERDEPROPERTIES
+  */
+case class TextfileWithRegEx(inputRegex: String) extends StorageFormat
+
+/**
+  * Convenience case class to store a view's data
+  * as TextFile, but automatically setting ROW FORMAT SERDE
+  * JsonSerDe
+  */
+case class Json() extends StorageFormat
+
+
+/**
+  * Convenience case class to store a view's data
+  * as TextFile, but automatically setting ROW FORMAT SERDE
+  * OpenCSVSerde
+  * Note: valid for both Comma/Tab Separated (CSV/TSV) formats
+  */
+case class Csv() extends StorageFormat
+
+/**
+  * Generic input Output specifier
+  * Store a view's data by specifying INPUT and OUTPUT format
+  *
+  * This case class is only present to allow support any format,
+  * it is translated to a STORED AS INPUTFORMAT _ OUTPUTFORMAT _
+  * clause
+  * In the case of serDe value present, the ROW FORMAT SERDE _
+  * is also present
+  *
+  * Example use case: LZO compression
+  */
+case class InOutputFormat(input: String, output: String, serDe: Option[String] = None) extends StorageFormat

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
@@ -95,20 +95,11 @@ class ViewManagerActor(settings: SchedoscopeSettings,
     }
   })
 
-
   /**
-    * Initialize view actors for a list of views. If a view actor has been produced for a view
-    * previously, that one is returned.
-    *
-    * @param vs           the views to create actors for
-    * @param dependencies create actors for the prerequisite views as well.
-    * @return the set of corresponding view actor refs
+    * Convenience "private" method to validate external Views and their dependencies
+    * prior to actor initialization
     */
-  def initializeViewActors(vs: List[View], dependencies: Boolean = false): Set[ActorRef] = {
-    log.info(s"Initializing ${vs.size} views")
-
-    val allViews = viewsToCreateActorsFor(vs, dependencies)
-
+  def validateExternalViews(allViews: List[(View, Boolean, Int)]):Unit =
     if (!settings.externalDependencies) {
       //external dependencies are not allowed
       val containsExternalDependencies = allViews.exists {
@@ -129,6 +120,21 @@ class ViewManagerActor(settings: SchedoscopeSettings,
         }
       }
     }
+
+  /**
+    * Initialize view actors for a list of views. If a view actor has been produced for a view
+    * previously, that one is returned.
+    *
+    * @param vs           the views to create actors for
+    * @param dependencies create actors for the prerequisite views as well.
+    * @return the set of corresponding view actor refs
+    */
+  def initializeViewActors(vs: List[View], dependencies: Boolean = false): Set[ActorRef] = {
+    log.info(s"Initializing ${vs.size} views")
+
+    val allViews = viewsToCreateActorsFor(vs, dependencies)
+
+    validateExternalViews(allViews)
 
     log.info(s"Computed ${allViews.size} views (with dependencies=${dependencies})")
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
@@ -107,7 +107,7 @@ class SchemaManager(val metastoreClient: IMetaStoreClient, val connection: Conne
       stmt.execute(s"DROP TABLE IF EXISTS ${view.dbName}.${view.n}")
     } catch {
       case t: Throwable =>
-        log.warn(s"Failed to drop existing table ${view.dbName}.${view.n}.", t)
+        log.warn(s"Failed to drop existing table ${view.dbName}.${view.n}.")
         throw t
     }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/SchemaManager.scala
@@ -101,9 +101,15 @@ class SchemaManager(val metastoreClient: IMetaStoreClient, val connection: Conne
     } catch {
       case t: Throwable =>
         log.warn(s"Could not create database ${view.dbName}. Maybe you simply do not have permission to execute CREATE TABLE statements. In this case, get an admin to create the database for you before running schedoscope.", t)
+        throw t
     }
-
-    stmt.execute(s"DROP TABLE IF EXISTS ${view.dbName}.${view.n}")
+    try {
+      stmt.execute(s"DROP TABLE IF EXISTS ${view.dbName}.${view.n}")
+    } catch {
+      case t: Throwable =>
+        log.warn(s"Failed to drop existing table ${view.dbName}.${view.n}.", t)
+        throw t
+    }
 
     log.info(s"Creating table:\n${ddl}")
 
@@ -111,6 +117,7 @@ class SchemaManager(val metastoreClient: IMetaStoreClient, val connection: Conne
 
     stmt.close()
 
+    log.info(s"Successfully created table ${view.dbName}.${view.n}; now adding Checksum '${HiveQl.ddlChecksum(view)}' to table properties.")
     setTableProperty(view.dbName, view.n, Checksum.SchemaChecksum.checksumProperty, HiveQl.ddlChecksum(view))
   } catch {
     case t: Throwable => {

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -132,6 +132,9 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
       case OptimizedRowColumnar() =>
         rowFormatSerDeDdl(view) + "\n\tSTORED AS ORC"
 
+      case RecordColumnarFile() =>
+        rowFormatSerDeDdl(view) + "\n\tSTORED AS RCFILE"
+
       case Json() | Csv() | TextfileWithRegEx(_) =>
         rowFormatSerDeDdl(view) + "\n\tSTORED AS TEXTFILE"
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -119,13 +119,13 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
       case TextFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
         // TODO: better collision validation ?
-        val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
+        val rowFormat = if (rfd.replaceAll("""(?m)\s+$""", "").length > 0) rfd else rowFormatSerDeDdl(view)
         rowFormat + "\n\tSTORED AS TEXTFILE"
 
       case SequenceFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
         // TODO: better collision validation ?
-        val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
+        val rowFormat = if (rfd.replaceAll("""(?m)\s+$""", "").length > 0) rfd else rowFormatSerDeDdl(view)
         rowFormat + "\n\tSTORED AS SEQUENCEFILE"
 
       case Parquet() =>

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -120,15 +120,21 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
         // TODO: better collision validation ?
         val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
-        rowFormat + inOutputFormatDdl(view)
+        rowFormat + "\n\tSTORED AS TEXTFILE"
 
       case SequenceFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
         // TODO: better collision validation ?
         val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
-        rowFormat + inOutputFormatDdl(view)
+        rowFormat + "\n\tSTORED AS SEQUENCEFILE"
 
-      case Parquet() | Avro(_) | OptimizedRowColumnar() | TextfileWithRegEx(_) | Json() | Csv() | InOutputFormat(_, _, _) =>
+      case Parquet() =>
+        rowFormatSerDeDdl(view) + "\n\tSTORED AS PARQUET"
+
+      case OptimizedRowColumnar() =>
+        rowFormatSerDeDdl(view) + "\n\tSTORED AS ORC"
+
+      case Avro(_) | Json() | Csv() | TextfileWithRegEx(_) | InOutputFormat(_, _, _) =>
         rowFormatSerDeDdl(view) + inOutputFormatDdl(view)
 
       case _ => inOutputFormatDdl(view)

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -114,25 +114,26 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
       s"\n\t\tINPUTFORMAT '${view.inOutputformat("input")}'" +
       s"\n\t\tOUTPUTFORMAT '${view.inOutputformat("output")}'"
 
-  def storedAsDdl(view: View) =  view.storageFormat match {
+  def storedAsDdl(view: View) = view.storageFormat match {
 
-    case TextFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
-      val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
-      // TODO: better collision validation ?
-      val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
-      rowFormat  + inOutputFormatDdl(view)
+      case TextFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
+        val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
+        // TODO: better collision validation ?
+        val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
+        rowFormat + inOutputFormatDdl(view)
 
-    case SequenceFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
-      val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
-      // TODO: better collision validation ?
-      val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
-      rowFormat + inOutputFormatDdl(view)
+      case SequenceFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
+        val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
+        // TODO: better collision validation ?
+        val rowFormat = if (rfd.length > 0) rfd else rowFormatSerDeDdl(view)
+        rowFormat + inOutputFormatDdl(view)
 
-    case Parquet() | Avro(_) | OptimizedRowColumnar() | TextfileWithRegEx(_) | Json() | Csv() | InOutputFormat(_,_,_) =>
-      rowFormatSerDeDdl(view) + inOutputFormatDdl(view)
+      case Parquet() | Avro(_) | OptimizedRowColumnar() | TextfileWithRegEx(_) | Json() | Csv() | InOutputFormat(_, _, _) =>
+        rowFormatSerDeDdl(view) + inOutputFormatDdl(view)
 
-    case _ => inOutputFormatDdl(view)
-  }
+      case _ => inOutputFormatDdl(view)
+    }
+
 
   def tblPropertiesDdl(view: View) =
     if (view.tblProperties.isEmpty)
@@ -174,11 +175,11 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
   }
 
   def ddlChecksum(view: View) = Checksum.digest(
-    view.storageFormat match {
-      case Avro(schemaPath) => ddl(view).replaceAll(Regex.quoteReplacement(s"${view.avroSchemaPathPrefix}/${schemaPath}"), "")
-      case _ => ddl(view)
-    }
-  )
+      view.storageFormat match {
+        case Avro(schemaPath) => ddl(view).replaceAll(Regex.quoteReplacement(s"${view.avroSchemaPathPrefix}/${schemaPath}"), "")
+        case _ => ddl(view)
+      }
+    )
 
   def selectAll(view: View): String = s"SELECT * FROM ${view.tableName} ${partitionWhereClause(view)}"
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -78,7 +78,7 @@ object HiveQl {
 
   private def mapToString(m: HashMap[String, String]) = {
     val result = m.foldLeft("") { (s: String, pair: (String, String)) =>
-        s + "\n\t\t '" + pair._1 + "'" + " = " + "'" + pair._2 + "'" + "," }
+        s + "\n\t\t '" + pair._1 + "'" + " = " + "'" + pair._2 + "' ," }
     if(result.length > 0)
       result.dropRight(1)
     else

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -78,7 +78,7 @@ object HiveQl {
 
   private def mapToString(m: HashMap[String, String]) = {
     val result = m.foldLeft("") { (s: String, pair: (String, String)) =>
-        s + "\n\t\t '" + pair._1 + "'" + " = " + "'" + pair._2 + "' ," }
+        s + "\n\t\t '" + pair._1 + "'" + " = " + "'" + pair._2 + "'," }
     if(result.length > 0)
       result.dropRight(1)
     else

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -134,10 +134,13 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
       case OptimizedRowColumnar() =>
         rowFormatSerDeDdl(view) + "\n\tSTORED AS ORC"
 
-      case Avro(_) | Json() | Csv() | TextfileWithRegEx(_) | InOutputFormat(_, _, _) =>
+      case Json() | Csv() | TextfileWithRegEx(_) =>
+        rowFormatSerDeDdl(view) + "\n\tSTORED AS TEXTFILE"
+
+      case Avro(_) | InOutputFormat(_, _, _) =>
         rowFormatSerDeDdl(view) + inOutputFormatDdl(view)
 
-      case _ => inOutputFormatDdl(view)
+      case _ => rowFormatSerDeDdl(view) + inOutputFormatDdl(view)
     }
 
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/schema/ddl/HiveQl.scala
@@ -118,13 +118,11 @@ ${if (mapKeyTerminator != null) s"\tMAP KEYS TERMINATED BY '${mapKeyTerminator}'
 
       case TextFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
-        // TODO: better collision validation ?
         val rowFormat = if (rfd.replaceAll("""(?m)\s+$""", "").length > 0) rfd else rowFormatSerDeDdl(view)
         rowFormat + "\n\tSTORED AS TEXTFILE"
 
       case SequenceFile(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator) =>
         val rfd = rowFormatDelimitedDdl(fieldTerminator, collectionItemTerminator, mapKeyTerminator, lineTerminator)
-        // TODO: better collision validation ?
         val rowFormat = if (rfd.replaceAll("""(?m)\s+$""", "").length > 0) rfd else rowFormatSerDeDdl(view)
         rowFormat + "\n\tSTORED AS SEQUENCEFILE"
 

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -133,7 +133,6 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
 
   it should "generate TextFile2 row format and tblproperties sql statement" in {
     val view = ArticleViewTextFile2()
-    println(HiveQl.ddl(view))
     HiveQl.ddl(view) shouldEqual
       """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_text_file2 (
         |		name STRING,
@@ -149,6 +148,21 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		 'what' = 'buh'
         |	)
         |	LOCATION '/hdp/dev/test/views/article_view_text_file2'
+        |""".stripMargin
+  }
+
+  it should "generate Record Columnar format and tblproperties sql statement" in {
+    val view = ArticleViewRc()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_rc (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	STORED AS RCFILE
+        |	TBLPROPERTIES (
+        |		 'scalable' = 'true'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_rc'
         |""".stripMargin
   }
 

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -67,10 +67,7 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		name STRING,
         |		number INT
         |	)
-        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
-        |	STORED AS
-        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
-        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+        |	STORED AS PARQUET
         |	TBLPROPERTIES (
         |		 'orc.compress' = 'ZLIB',
         |		 'transactional' = 'true'
@@ -142,10 +139,7 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		name STRING,
         |		number INT
         |	)
-        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
-        |	STORED AS
-        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
-        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+        |	STORED AS ORC
         |	TBLPROPERTIES (
         |		 'orc.compress' = 'ZLIB',
         |		 'transactional' = 'true'

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -152,8 +152,8 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |	)
         |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
         |	WITH SERDEPROPERTIES (
-        |		 'escapeChar' = '\\',
-        |		 'separatorChar' = '\t'
+        |		 'separatorChar' = '\t',
+        |		 'escapeChar' = '\\'
         |	)
         |	STORED AS TEXTFILE
         |	TBLPROPERTIES (
@@ -203,9 +203,9 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |	)
         |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
         |	WITH SERDEPROPERTIES (
+        |		 'separatorChar' = '\t',
         |		 'quoteChar' = ''',
-        |		 'escapeChar' = '\\',
-        |		 'separatorChar' = '\t'
+        |		 'escapeChar' = '\\'
         |	)
         |	STORED AS TEXTFILE
         |	LOCATION '/hdp/dev/test/views/article_view_csv'

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -101,8 +101,7 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
         |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
         |	TBLPROPERTIES (
-        |		 'immutable' = 'true',
-        |		 'avro.schema.url' = 'hdfs:///hdp/dev/global/datadictionary/schema/avro/myPath'
+        |		 'immutable' = 'true'
         |	)
         |	LOCATION '/hdp/dev/test/views/article_view_avro'
         |""".stripMargin

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -76,6 +76,18 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |""".stripMargin
   }
 
+  it should "generate Sequence file row format" in {
+    val view = ArticleViewSequence()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_sequence (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	STORED AS SEQUENCEFILE
+        |	LOCATION '/hdp/dev/test/views/article_view_sequence'
+        |""".stripMargin
+  }
+
   it should "generate avro row format and tblproperties sql statement" in {
     val view = ArticleViewAvro()
     val hack = ""

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -96,6 +96,62 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |""".stripMargin
   }
 
+  it should "generate ORC row format and tblproperties sql statement" in {
+    val view = ArticleViewOrc()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_orc (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	STORED AS ORC
+        |	TBLPROPERTIES (
+        |		 'immutable' = 'false'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_orc'
+        |""".stripMargin
+  }
+
+  it should "generate TextFile row format and tblproperties sql statement" in {
+    val view = ArticleViewTextFile1()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_text_file1 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT DELIMITED
+        |	FIELDS TERMINATED BY '\\001'
+        |	LINES TERMINATED BY '\n'
+        |	COLLECTION ITEMS TERMINATED BY '\002'
+        |	MAP KEYS TERMINATED BY '\003'
+        |	STORED AS TEXTFILE
+        |	TBLPROPERTIES (
+        |		 'what' = 'ever'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_text_file1'
+        |""".stripMargin
+  }
+
+  it should "generate TextFile2 row format and tblproperties sql statement" in {
+    val view = ArticleViewTextFile2()
+    println(HiveQl.ddl(view))
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_text_file2 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+        |	WITH SERDEPROPERTIES (
+        |		 'escapeChar' = '\\',
+        |		 'separatorChar' = '\t'
+        |	)
+        |	STORED AS TEXTFILE
+        |	TBLPROPERTIES (
+        |		 'what' = 'buh'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_text_file2'
+        |""".stripMargin
+  }
+
   it should "generate json row format and tblproperties sql statement" in {
     val view = ArticleViewJson()
     HiveQl.ddl(view) shouldEqual

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -22,6 +22,9 @@ import org.schedoscope.dsl.Parameter.p
 import org.schedoscope.dsl.transformations.HiveTransformation.queryFromResource
 import org.schedoscope.dsl.transformations.Transformation.replaceParameters
 import org.schedoscope.dsl.{Parameter, Structure, View}
+import org.schedoscope.schema.ddl.HiveQl
+import test.views._
+
 
 case class Article() extends Structure {
   val name = fieldOf[String]
@@ -56,6 +59,100 @@ case class OrderAll(year: Parameter[Int], month: Parameter[Int], day: Parameter[
 }
 
 class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
+
+  it should "generate Parquet row format and tblproperties sql statement" in {
+    val view = ArticleViewParquet()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_parquet (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'orc.compress' = 'ZLIB',
+        |		 'transactional' = 'true'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_parquet'
+        |""".stripMargin
+  }
+
+  it should "generate avro row format and tblproperties sql statement" in {
+    val view = ArticleViewAvro()
+    val hack = ""
+    HiveQl.ddl(view) shouldEqual
+      s"""	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_avro ${hack}
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+        |	WITH SERDEPROPERTIES (
+        |		 'avro.schema.url' = 'hdfs:///hdp/dev/global/datadictionary/schema/avro/myPath'
+        |	)
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'immutable' = 'true',
+        |		 'avro.schema.url' = 'hdfs:///hdp/dev/global/datadictionary/schema/avro/myPath'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_avro'
+        |""".stripMargin
+  }
+
+  it should "generate json row format and tblproperties sql statement" in {
+    val view = ArticleViewJson()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_json (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'transactional' = 'true'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_json'
+        |""".stripMargin
+  }
+
+  it should "generate inputOutput row format and tblproperties sql statement" in {
+    val view = ArticleViewInOutput()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_in_output (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'EXTERNAL' = 'TRUE'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_in_output'
+        |""".stripMargin
+  }
+
+  it should "generate S3 row format and tblproperties sql statement" in {
+    val view = ArticleViewS3()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_s3 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'orc.compress' = 'ZLIB',
+        |		 'transactional' = 'true'
+        |	)
+        |	LOCATION 's3a://schedoscope-bucket-test/dev/test/views/article_view_s3'
+        |""".stripMargin
+  }
 
   "HiveTransformation.insertInto" should "generate correct static partitioning prefix by default" in {
     val orderAll = OrderAll(p(2014), p(10), p(12))

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -104,13 +104,45 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		number INT
         |	)
         |	ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
-        |	STORED AS
-        |		INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
-        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
+        |	STORED AS TEXTFILE
         |	TBLPROPERTIES (
         |		 'transactional' = 'true'
         |	)
         |	LOCATION '/hdp/dev/test/views/article_view_json'
+        |""".stripMargin
+  }
+
+  it should "generate custom serde with properties and stored as textfile" in {
+    val view = ArticleViewCsv()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_csv (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+        |	WITH SERDEPROPERTIES (
+        |		 'quoteChar' = ''',
+        |		 'escapeChar' = '\\',
+        |		 'separatorChar' = '\t'
+        |	)
+        |	STORED AS TEXTFILE
+        |	LOCATION '/hdp/dev/test/views/article_view_csv'
+        |""".stripMargin
+  }
+
+  it should "generate custom RegEx serde with properties and stored as textfile" in {
+    val view = ArticleViewRegEx()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_reg_ex (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
+        |	WITH SERDEPROPERTIES (
+        |		 'input.regex' = 'test'
+        |	)
+        |	STORED AS TEXTFILE
+        |	LOCATION '/hdp/dev/test/views/article_view_reg_ex'
         |""".stripMargin
   }
 

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/HiveQlTest.scala
@@ -76,6 +76,21 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |""".stripMargin
   }
 
+  it should "generate Parquet row format sql statement" in {
+    val view = ArticleViewParquet2()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_parquet2 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+        |	LOCATION '/hdp/dev/test/views/article_view_parquet2'
+        |""".stripMargin
+  }
+
   it should "generate Sequence file row format" in {
     val view = ArticleViewSequence()
     HiveQl.ddl(view) shouldEqual
@@ -107,6 +122,19 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |""".stripMargin
   }
 
+  it should "generate avro consise format" in {
+    val view = ArticleViewAvro2()
+    val hack = ""
+    HiveQl.ddl(view) shouldEqual
+      s"""	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_avro2 ${hack}
+          |	STORED AS AVRO
+          |	TBLPROPERTIES (
+          |		 'immutable' = 'true'
+          |	)
+          |	LOCATION '/hdp/dev/test/views/article_view_avro2'
+          |""".stripMargin
+  }
+
   it should "generate ORC row format and tblproperties sql statement" in {
     val view = ArticleViewOrc()
     HiveQl.ddl(view) shouldEqual
@@ -119,6 +147,21 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		 'immutable' = 'false'
         |	)
         |	LOCATION '/hdp/dev/test/views/article_view_orc'
+        |""".stripMargin
+  }
+
+  it should "generate ORC row format sql statement" in {
+    val view = ArticleViewOrc2()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_orc2 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
+        |	LOCATION '/hdp/dev/test/views/article_view_orc2'
         |""".stripMargin
   }
 
@@ -159,6 +202,23 @@ class HiveQlTest extends FlatSpec with BeforeAndAfter with Matchers {
         |		 'what' = 'buh'
         |	)
         |	LOCATION '/hdp/dev/test/views/article_view_text_file2'
+        |""".stripMargin
+  }
+
+  it should "generate TextFile3 in row format" in {
+    val view = ArticleViewTextFile3()
+    HiveQl.ddl(view) shouldEqual
+      """	CREATE EXTERNAL TABLE IF NOT EXISTS dev_test_views.article_view_text_file3 (
+        |		name STRING,
+        |		number INT
+        |	)
+        |	STORED AS
+        |		INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+        |		OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat'
+        |	TBLPROPERTIES (
+        |		 'what' = 'buh'
+        |	)
+        |	LOCATION '/hdp/dev/test/views/article_view_text_file3'
         |""".stripMargin
   }
 

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -396,6 +396,14 @@ case class ArticleViewOrc() extends View {
   storedAs(OptimizedRowColumnar())
 }
 
+case class ArticleViewRc() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  setTblProperties(Map("scalable"->"true"))
+  storedAs(RecordColumnarFile())
+}
+
 case class ArticleViewCsv() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -388,6 +388,22 @@ case class ArticleViewAvro() extends View {
   storedAs(Avro("myPath"))
 }
 
+case class ArticleViewCsv() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  serDeProperties(Map("separatorChar"->"""\t""",
+    "quoteChar"->"'", "escapeChar"->"""\\"""))
+  storedAs(Csv())
+}
+
+case class ArticleViewRegEx() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  storedAs(TextfileWithRegEx("test"))
+}
+
 case class ArticleViewJson() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -376,7 +376,7 @@ case class ArticleViewParquet() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  setTblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
   storedAs(Parquet())
 }
 
@@ -384,7 +384,7 @@ case class ArticleViewAvro() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  tblProperties(Map("immutable"->"true"))
+  setTblProperties(Map("immutable"->"true"))
   storedAs(Avro("myPath"))
 }
 
@@ -392,7 +392,7 @@ case class ArticleViewJson() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  tblProperties(Map("transactional"->"true"))
+  setTblProperties(Map("transactional"->"true"))
   storedAs(Json())
 }
 
@@ -400,7 +400,7 @@ case class ArticleViewInOutput() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  tblProperties(Map("EXTERNAL"->"TRUE"))
+  setTblProperties(Map("EXTERNAL"->"TRUE"))
   storedAs(InOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
     "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
     Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde")))
@@ -410,6 +410,6 @@ case class ArticleViewS3() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  setTblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
   storedAs(S3("schedoscope-bucket-test", OptimizedRowColumnar(), "s3a"))
 }

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -415,16 +415,16 @@ case class ArticleViewCsv() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  serDeProperties(Map("separatorChar"->"""\t""",
-    "quoteChar"->"'", "escapeChar"->"""\\"""))
-  storedAs(Csv())
+  storedAs(Csv(serDeProperties = Map("separatorChar"->"""\t""",
+    "quoteChar"->"'", "escapeChar"->"""\\""")))
 }
 
 case class ArticleViewRegEx() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  storedAs(TextfileWithRegEx("test"))
+  storedAs(TextFile(serDe = "org.apache.hadoop.hive.serde2.RegexSerDe",
+    serDeProperties = Map("input.regex"-> "test")))
 }
 
 case class ArticleViewJson() extends View {
@@ -452,10 +452,9 @@ case class ArticleViewTextFile2() extends View {
   val number = fieldOf[Int]
 
   tblProperties(Map("what"->"buh"))
-  storedAs(TextFile())
-  rowFormat("org.apache.hadoop.hive.serde2.OpenCSVSerde")
-  serDeProperties(Map("separatorChar"->"""\t""",
-    "escapeChar"->"""\\"""))
+  storedAs(TextFile(serDe = "org.apache.hadoop.hive.serde2.OpenCSVSerde",
+    serDeProperties = Map("separatorChar"->"""\t""",
+    "escapeChar"->"""\\""")))
 }
 
 case class ArticleViewInOutput() extends View {
@@ -463,9 +462,9 @@ case class ArticleViewInOutput() extends View {
   val number = fieldOf[Int]
 
   tblProperties(Map("EXTERNAL"->"TRUE"))
-  storedAs(InOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
-    "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
-    Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde")))
+  storedAs(InOutputFormat(input = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
+    output = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
+    serDe = "org.apache.hadoop.hive.ql.io.orc.OrcSerde"))
 }
 
 case class ArticleViewS3() extends View {

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -376,7 +376,7 @@ case class ArticleViewParquet() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
   storedAs(Parquet())
 }
 
@@ -384,7 +384,7 @@ case class ArticleViewAvro() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("immutable"->"true"))
+  tblProperties(Map("immutable"->"true"))
   storedAs(Avro("myPath"))
 }
 
@@ -392,7 +392,7 @@ case class ArticleViewOrc() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("immutable"->"false"))
+  tblProperties(Map("immutable"->"false"))
   storedAs(OptimizedRowColumnar())
 }
 
@@ -400,7 +400,7 @@ case class ArticleViewRc() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("scalable"->"true"))
+  tblProperties(Map("scalable"->"true"))
   storedAs(RecordColumnarFile())
 }
 
@@ -424,7 +424,7 @@ case class ArticleViewJson() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("transactional"->"true"))
+  tblProperties(Map("transactional"->"true"))
   storedAs(Json())
 }
 
@@ -432,7 +432,7 @@ case class ArticleViewTextFile1() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("what"->"ever"))
+  tblProperties(Map("what"->"ever"))
   storedAs(TextFile(fieldTerminator = """\\001""",
     collectionItemTerminator = """\002""",
     mapKeyTerminator = """\003""",
@@ -444,7 +444,7 @@ case class ArticleViewTextFile2() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("what"->"buh"))
+  tblProperties(Map("what"->"buh"))
   storedAs(TextFile())
   rowFormat("org.apache.hadoop.hive.serde2.OpenCSVSerde")
   serDeProperties(Map("separatorChar"->"""\t""",
@@ -455,7 +455,7 @@ case class ArticleViewInOutput() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("EXTERNAL"->"TRUE"))
+  tblProperties(Map("EXTERNAL"->"TRUE"))
   storedAs(InOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
     "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
     Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde")))
@@ -465,6 +465,6 @@ case class ArticleViewS3() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
-  setTblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
   storedAs(S3("schedoscope-bucket-test", OptimizedRowColumnar(), "s3a"))
 }

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -380,6 +380,13 @@ case class ArticleViewParquet() extends View {
   storedAs(Parquet())
 }
 
+case class ArticleViewParquet2() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  storedAs(Parquet(fullRowFormatCreateTblStmt = true))
+}
+
 case class ArticleViewSequence() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
@@ -395,12 +402,27 @@ case class ArticleViewAvro() extends View {
   storedAs(Avro("myPath"))
 }
 
+case class ArticleViewAvro2() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("immutable"->"true"))
+  storedAs(Avro("myPath", fullRowFormatCreateTblStmt = false))
+}
+
 case class ArticleViewOrc() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
 
   tblProperties(Map("immutable"->"false"))
   storedAs(OptimizedRowColumnar())
+}
+
+case class ArticleViewOrc2() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  storedAs(OptimizedRowColumnar(fullRowFormatCreateTblStmt = true))
 }
 
 case class ArticleViewRc() extends View {
@@ -455,6 +477,14 @@ case class ArticleViewTextFile2() extends View {
   storedAs(TextFile(serDe = "org.apache.hadoop.hive.serde2.OpenCSVSerde",
     serDeProperties = Map("separatorChar"->"""\t""",
     "escapeChar"->"""\\""")))
+}
+
+case class ArticleViewTextFile3() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("what"->"buh"))
+  storedAs(TextFile(fullRowFormatCreateTblStmt = true))
 }
 
 case class ArticleViewInOutput() extends View {

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -380,6 +380,13 @@ case class ArticleViewParquet() extends View {
   storedAs(Parquet())
 }
 
+case class ArticleViewSequence() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  storedAs(SequenceFile())
+}
+
 case class ArticleViewAvro() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -388,6 +388,14 @@ case class ArticleViewAvro() extends View {
   storedAs(Avro("myPath"))
 }
 
+case class ArticleViewOrc() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  setTblProperties(Map("immutable"->"false"))
+  storedAs(OptimizedRowColumnar())
+}
+
 case class ArticleViewCsv() extends View {
   val name = fieldOf[String]
   val number = fieldOf[Int]
@@ -410,6 +418,29 @@ case class ArticleViewJson() extends View {
 
   setTblProperties(Map("transactional"->"true"))
   storedAs(Json())
+}
+
+case class ArticleViewTextFile1() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  setTblProperties(Map("what"->"ever"))
+  storedAs(TextFile(fieldTerminator = """\\001""",
+    collectionItemTerminator = """\002""",
+    mapKeyTerminator = """\003""",
+    lineTerminator = """\n"""
+  ))
+}
+
+case class ArticleViewTextFile2() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  setTblProperties(Map("what"->"buh"))
+  storedAs(TextFile())
+  rowFormat("org.apache.hadoop.hive.serde2.OpenCSVSerde")
+  serDeProperties(Map("separatorChar"->"""\t""",
+    "escapeChar"->"""\\"""))
 }
 
 case class ArticleViewInOutput() extends View {

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -16,7 +16,7 @@
 package test.views
 
 import org.schedoscope.dsl.Parameter._
-import org.schedoscope.dsl.storageformats.{Avro, Parquet, TextFile}
+import org.schedoscope.dsl.storageformats._
 import org.schedoscope.dsl.transformations.Export._
 import org.schedoscope.dsl.transformations.HiveTransformation
 import org.schedoscope.dsl.transformations.HiveTransformation._
@@ -372,3 +372,44 @@ case class RequireView(shopCode: Parameter[String])
   val field1 = fieldOf[String]
 }
 
+case class ArticleViewParquet() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  storedAs(Parquet())
+}
+
+case class ArticleViewAvro() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("immutable"->"true"))
+  storedAs(Avro("myPath"))
+}
+
+case class ArticleViewJson() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("transactional"->"true"))
+  storedAs(Json())
+}
+
+case class ArticleViewInOutput() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("EXTERNAL"->"TRUE"))
+  storedAs(InOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
+    "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
+    Some("org.apache.hadoop.hive.ql.io.orc.OrcSerde")))
+}
+
+case class ArticleViewS3() extends View {
+  val name = fieldOf[String]
+  val number = fieldOf[Int]
+
+  tblProperties(Map("orc.compress"->"ZLIB", "transactional" -> "true"))
+  storedAs(S3("schedoscope-bucket-test", OptimizedRowColumnar(), "s3a"))
+}


### PR DESCRIPTION
@utzwestermann @lofifnc
PR goal:
Allow to add TBLPROPERTIES() to views + enable flexible additions of storage formats and custom SerDe

PR summary:
- expanded HiveQl for tblproperties addition;
- refactor HiveQl so that storedAsDdl also automatically adjusts to ROW FORMAT / SerDeProperties;
- refactored views to allow addition of any storage format, tblProperties, serDe and serDe Properties;
- Added experimental AWS S3 as hive table storage (changed dbPathBuilder);
- Updated Wiki: https://github.com/diogoaurelio/schedoscopeWiki/pull/3