### PR TITLE
Remove Queue from TransformationManagerActor

### DIFF
--- a/schedoscope-conf/src/main/resources/reference.conf
+++ b/schedoscope-conf/src/main/resources/reference.conf
@@ -928,6 +928,17 @@ akka {
     }
 
     #
+    # The Router actor managing and instantiating driver actors
+    # has one dedicated pinned dispatcher / thread for reasons of
+    # responsiveness.
+    #
+
+    driver-router-dispatcher {
+      executor = "thread-pool-executor"
+      type = PinnedDispatcher
+    }
+
+    #
     # The threadpool / dispatcher available for the transformation drivers.
     # As drivers execute transformations asynchronously - either by
     # communicating with servers like Oozie or the Resource Manager or by
@@ -942,7 +953,7 @@ akka {
       thread-pool-executor {
         core-pool-size-min = 8
         core-pool-size-factor = 2.0
-        core-pool-size-max = 8
+        core-pool-size-max = 48
         task-queue-size = -1
       }
 

--- a/schedoscope-conf/src/main/resources/reference.conf
+++ b/schedoscope-conf/src/main/resources/reference.conf
@@ -949,11 +949,12 @@ akka {
     driver-dispatcher {
       executor = "thread-pool-executor"
       type = Dispatcher
+      mailbox-type = "org.schedoscope.scheduler.actors.DriverPriorityMailbox"
 
       thread-pool-executor {
         core-pool-size-min = 8
         core-pool-size-factor = 2.0
-        core-pool-size-max = 48
+        core-pool-size-max = 8
         task-queue-size = -1
       }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverActor.scala
@@ -64,7 +64,7 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
 
     logStateInfo("idle", "DRIVER ACTOR: initialized actor")
 
-    tick()
+    //tick()
   }
 
   /**
@@ -89,10 +89,12 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
   def receive = LoggingReceive {
     case t: DriverCommand => toRunning(t)
 
+    /*
     case "tick" => {
       transformationManagerActor ! PollCommand(driver.transformationName)
       tick()
     }
+    */
   }
 
   /**
@@ -128,7 +130,6 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
               log.error(s"DRIVER ACTOR: Driver run for handle=${runHandle} failed because completion handler threw exception ${t}, trace ${ExceptionUtils.getStackTrace(t)}")
               originalSender ! TransformationFailure(runHandle, DriverRunFailed[T](driver, "Completition handler failed", t))
               toReceive()
-              tick()
             }
           }
 
@@ -146,7 +147,6 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
 
           originalSender ! TransformationSuccess(runHandle, success, viewHasData)
           toReceive()
-          tick()
         }
 
         case failure: DriverRunFailed[T] => {
@@ -163,7 +163,6 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
 
           originalSender ! TransformationFailure(runHandle, failure)
           toReceive()
-          tick()
         }
       }
     } catch {
@@ -220,7 +219,7 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
           driver.driverRunStarted(runHandle)
 
           logStateInfo("running", s"DRIVER ACTOR: Running transformation ${transformation}, configuration=${transformation.configuration}, runHandle=${runHandle}", runHandle, driver.getDriverRunState(runHandle))
-
+          tick()
           become(running(runHandle, commandToRun.sender, Some(view)))
         case t: Transformation =>
           val transformation: T = t.asInstanceOf[T]
@@ -229,7 +228,7 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
           driver.driverRunStarted(runHandle)
 
           logStateInfo("running", s"DRIVER ACTOR: Running transformation ${transformation}, configuration=${transformation.configuration}, runHandle=${runHandle}", runHandle, driver.getDriverRunState(runHandle))
-
+          tick()
           become(running(runHandle, commandToRun.sender, None))
       }
     } catch {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverPriorityMailbox.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverPriorityMailbox.scala
@@ -1,0 +1,31 @@
+/**
+  * Copyright 2015 Otto (GmbH & Co KG)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package org.schedoscope.scheduler.actors
+
+import akka.actor.ActorSystem
+import akka.dispatch.PriorityGenerator
+import akka.dispatch.UnboundedPriorityMailbox
+import com.typesafe.config.Config
+
+class DriverPriorityMailbox(settings: ActorSystem.Settings, config: Config)
+  extends UnboundedPriorityMailbox (
+    // Note: lower prio means more important
+    PriorityGenerator {
+      // prioritize tick for progress tracking
+      case "tick" => 0
+      // else default
+      case _ => 1
+    })

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverPriorityMailbox.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverPriorityMailbox.scala
@@ -20,6 +20,13 @@ import akka.dispatch.PriorityGenerator
 import akka.dispatch.UnboundedPriorityMailbox
 import com.typesafe.config.Config
 
+/**
+  * A driver actor requires prioritization of tick messages,
+  * in order to guarantee successful progress tracking, and
+  * to new Mailbox successful moving forward to Mailbox queued
+  * transformation tasks
+  *
+  */
 class DriverPriorityMailbox(settings: ActorSystem.Settings, config: Config)
   extends UnboundedPriorityMailbox (
     // Note: lower prio means more important

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+
 /**
   * The transformation manager actor queues transformation requests it receives from view actors by
   * transformation type. Idle driver actors poll the transformation manager for new transformations to perform.
@@ -138,7 +139,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
       for(transformation <- Driver.transformationsWithDrivers) {
         actorOf(
           BalancingPool(nrOfInstances = settings.getDriverSettings(transformation).concurrency,
-            supervisorStrategy = driverManagersupervisorStrategy, routerDispatcher = "driver-dispatcher")
+            supervisorStrategy = driverManagersupervisorStrategy, routerDispatcher = "akka.actor.driver-dispatcher")
             .props(routeeProps = DriverActor.props(settings, transformation, self)),
           s"${transformation}-router")
       }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -15,7 +15,7 @@
   */
 package org.schedoscope.scheduler.actors
 
-import akka.actor.{Actor, ActorInitializationException, OneForOneStrategy, Props}
+import akka.actor.{Actor, ActorInitializationException, ActorRef, OneForOneStrategy, Props}
 import akka.actor.SupervisorStrategy._
 import akka.event.{Logging, LoggingReceive}
 import akka.routing._

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -15,10 +15,10 @@
   */
 package org.schedoscope.scheduler.actors
 
-import akka.actor.{Actor, ActorInitializationException, ActorRef, OneForOneStrategy, Props}
+import akka.actor.{Actor, ActorInitializationException, OneForOneStrategy, Props}
 import akka.actor.SupervisorStrategy._
 import akka.event.{Logging, LoggingReceive}
-import akka.routing.{ActorRefRoutee, BalancingPool, RoundRobinRouter, Router}
+import akka.routing._
 import org.schedoscope.conf.SchedoscopeSettings
 import org.schedoscope.dsl.View
 import org.schedoscope.dsl.transformations.{FilesystemTransformation, Transformation}
@@ -26,9 +26,7 @@ import org.schedoscope.scheduler.driver.{Driver, RetryableDriverException}
 import org.schedoscope.scheduler.messages._
 
 import scala.collection.JavaConversions.asScalaSet
-import scala.collection.mutable
 import scala.collection.mutable.HashMap
-import scala.util.Random
 
 
 /**
@@ -55,7 +53,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
     }
 
   // used for determining BalancingDispatcher children' Supervision
-  lazy val driverManagersupervisorStrategy = OneForOneStrategy(maxNrOfRetries = -1) {
+  lazy val driverRouterSupervisorStrategy = OneForOneStrategy(maxNrOfRetries = -1) {
     case _: RetryableDriverException => Restart
     case _: ActorInitializationException => Restart
     case _ => Escalate
@@ -63,88 +61,21 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
 
   val driverStates = HashMap[String, TransformationStatusResponse[_]]()
 
-  // create a queue for each driver that is not a filesystem driver
-
-  /*
-  val nonFilesystemQueues: Map[String, mutable.Queue[DriverCommand]] = Driver.transformationsWithDrivers.filter {
-    _ != "filesystem"
-  }.foldLeft(Map[String, collection.mutable.Queue[DriverCommand]]()) {
-    (nonFilesystemQueuesSoFar, transformationName) =>
-      nonFilesystemQueuesSoFar + (transformationName -> new collection.mutable.Queue[DriverCommand]())
-  }
-
-  val filesystemConcurrency = settings.getDriverSettings("filesystem").concurrency
-
-  val filesystemQueues = (0 until filesystemConcurrency).foldLeft(Map[String, collection.mutable.Queue[DriverCommand]]()) {
-    (filesystemQueuesSoFar, n) => filesystemQueuesSoFar + (s"filesystem-${n}" -> new collection.mutable.Queue[DriverCommand]())
-  }
-
-  val queues = nonFilesystemQueues ++ filesystemQueues
-
-  val randomizer = Random
-
-  def hash(s: String) = Math.max(0,
-    s.hashCode().abs % filesystemConcurrency)
-
-  def queueNameForTransformation(t: Transformation, s: ActorRef) =
-    if (t.name != "filesystem")
-      t.name
-    else {
-      val h = s"filesystem-${hash(s.path.name)}"
-      log.debug("computed hash: " + h + " for " + s.path.name)
-      h
-    }
-
-  def queueNameForTransformationType(transformationType: String) =
-    if (transformationType != "filesystem") {
-      transformationType
-    } else {
-      val allFilesystemQueuesEmpty = filesystemQueues.values.forall(currentQueue => currentQueue.isEmpty)
-
-      if (allFilesystemQueuesEmpty)
-        "filesystem-0"
-      else {
-        var foundNonEmptyQueue = false
-        var randomPick = ""
-
-        while (!foundNonEmptyQueue) {
-          randomPick = s"filesystem-${randomizer.nextInt(filesystemConcurrency)}"
-          foundNonEmptyQueue = !queues.get(randomPick).isEmpty
-        }
-
-        randomPick
-      }
-    }
-
-  def transformationQueueStatus() = {
-    queues.map(q => (q._1, q._2.map(c => c.command).toList))
-  }
-  */
-
   /**
     * Create driver actors as required by configured transformation types and their concurrency.
     */
   override def preStart {
-    /*
-    if (bootstrapDriverActors) {
-      for (transformation <- Driver.transformationsWithDrivers; c <- 0 until settings.getDriverSettings(transformation).concurrency) {
-        actorOf(DriverActor.props(settings, transformation, self), s"${transformation}-${c + 1}")
-      }
-    }
-    */
 
-    // TODO: self? | routees namespace ?
     if(bootstrapDriverActors) {
-
       for(transformation <- Driver.transformationsWithDrivers) {
         actorOf(
-          BalancingPool(nrOfInstances = settings.getDriverSettings(transformation).concurrency,
-            supervisorStrategy = driverManagersupervisorStrategy, routerDispatcher = "akka.actor.driver-dispatcher")
+          SmallestMailboxPool(nrOfInstances = settings.getDriverSettings(transformation).concurrency,
+            supervisorStrategy = driverRouterSupervisorStrategy,
+            routerDispatcher = "akka.actor.driver-router-dispatcher")
             .props(routeeProps = DriverActor.props(settings, transformation, self)),
           s"${transformation}-router")
       }
     }
-
   }
 
   /**
@@ -156,77 +87,28 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
 
     case GetTransformations() => sender ! TransformationStatusListResponse(driverStates.values.toList)
 
-    /*
-    case GetQueues() => sender ! QueueStatusListResponse(transformationQueueStatus())
-
-    case PollCommand(transformationType) => {
-      val queueForType = queues(queueNameForTransformationType(transformationType))
-
-      if (queueForType.nonEmpty) {
-        val cmd = queueForType.dequeue()
-
-        sender ! cmd
-
-        cmd.command match {
-          case TransformView(transformation, _) =>
-            log.info(s"TRANSFORMATIONMANAGER DEQUEUE: Dequeued ${transformationType} transformation${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queueForType.size}")
-          case transformation: Transformation =>
-            log.info(s"TRANSFORMATIONMANAGER DEQUEUE: Dequeued ${transformationType} transformation${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queueForType.size}")
-          case DeployCommand() =>
-            log.info("TRANSFORMATIONMANAGER DEQUEUE: Dequeued deploy action")
-        }
-      }
-    }
-    */
-
     case commandToExecute: DriverCommand =>
       commandToExecute.command match {
         case TransformView(transformation, view) =>
           context.actorSelection(s"${self.path}/${transformation}-router") forward commandToExecute
-          //enqueueTransformation(commandToExecute, transformation)
         case DeployCommand() =>
           context.actorSelection(s"${self.path}/*-router") forward commandToExecute
-          //enqueueDeploy(commandToExecute)
         case transformation: Transformation =>
           context.actorSelection(s"${self.path}/${transformation.name}-router") forward commandToExecute
-          //enqueueTransformation(commandToExecute, transformation)
       }
-
 
     case viewToTransform: View =>
       val transformation = viewToTransform.transformation().forView(viewToTransform)
       val commandRequest = DriverCommand(TransformView(transformation, viewToTransform), sender)
-      // TODO: forward!
       context.actorSelection(s"${self.path}/${transformation.name}-router") forward commandRequest
-      //enqueueTransformation(commandRequest, transformation)
 
     case filesystemTransformation: FilesystemTransformation =>
       val driverCommand = DriverCommand(filesystemTransformation, sender)
-      // TODO: forward!
       context.actorSelection(s"${self.path}/${filesystemTransformation.name}-router") forward driverCommand
-      //enqueueTransformation(driverCommand, filesystemTransformation)
 
     case deploy: DeployCommand =>
-      //// TODO: forward!
       context.actorSelection(s"${self.path}/*-router") forward DriverCommand(deploy, sender)
-      //enqueueDeploy(DriverCommand(deploy, sender))
   })
-
-  /*
-  def enqueueTransformation(commandToExecute: DriverCommand, transformation: Transformation): Unit = {
-    val queueName = queueNameForTransformation(transformation, commandToExecute.sender)
-
-    queues(queueName).enqueue(commandToExecute)
-    log.info(s"TRANSFORMATIONMANAGER ENQUEUE: Enqueued ${queueName} transformation${if (transformation.view.isDefined) s" for view ${transformation.view.get}" else ""}; queue size is now: ${queues.get(queueName).get.size}")
-  }
-
-  def enqueueDeploy(driverCommand: DriverCommand ): Unit = {
-    queues.values.foreach {
-      _.enqueue(driverCommand)
-    }
-    log.info("TRANSFORMATIONMANAGER ENQUEUE: Enqueued deploy action")
-  }
-  */
 
 }
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -93,7 +93,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
         case TransformView(transformation, view) =>
           context.actorSelection(s"${self.path}/${transformation}-router") forward commandToExecute
         case DeployCommand() =>
-          context.actorSelection(s"${self.path}/*-router") forward commandToExecute
+          context.actorSelection(s"${self.path}/*-router/*") forward commandToExecute
         case transformation: Transformation =>
           context.actorSelection(s"${self.path}/${transformation.name}-router") forward commandToExecute
       }
@@ -108,7 +108,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
       context.actorSelection(s"${self.path}/${filesystemTransformation.name}-router") forward driverCommand
 
     case deploy: DeployCommand =>
-      context.actorSelection(s"${self.path}/*-router") forward DriverCommand(deploy, sender)
+      context.actorSelection(s"${self.path}/*-router/*") forward DriverCommand(deploy, sender)
   })
 
 }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -30,8 +30,9 @@ import scala.collection.mutable.HashMap
 
 
 /**
-  * The transformation manager actor queues transformation requests it receives from view actors by
-  * transformation type. Idle driver actors poll the transformation manager for new transformations to perform.
+  * The transformation manager actor serves as a factory for all transformation requests, which are sent by view actors.
+  * It pushes all requests to the correspondent transformation type driver router, which, in turn, load balances work
+  * among its children, the Driver Actors.
   *
   */
 class TransformationManagerActor(settings: SchedoscopeSettings,
@@ -62,7 +63,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
   val driverStates = HashMap[String, TransformationStatusResponse[_]]()
 
   /**
-    * Create driver actors as required by configured transformation types and their concurrency.
+    * Create one driver router per transformation type, which themselves spawn driver actors as required by configured transformation concurrency.
     */
   override def preStart {
 

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewSchedulingListenerManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewSchedulingListenerManagerActor.scala
@@ -97,7 +97,7 @@ class ViewSchedulingListenerManagerActor(settings: SchedoscopeSettings) extends 
   def receive: Receive = LoggingReceive({
 
     case ViewSchedulingMonitoringEvent(prevState, newState, actions, eventTime) =>
-      context.actorSelection("*") ! ViewSchedulingMonitoringEvent(prevState, newState, actions, eventTime)
+      context.actorSelection(s"${self.path}/*") ! ViewSchedulingMonitoringEvent(prevState, newState, actions, eventTime)
       viewsMonitored += (prevState.view -> ViewSchedulingMonitoringEvent(prevState, newState, actions, eventTime))
 
     case CollectViewSchedulingStatus(handlerClassName) =>

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliCommandRunner.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliCommandRunner.scala
@@ -98,10 +98,11 @@ class SchedoscopeCliCommandRunner(schedoscope: SchedoscopeService) {
             case TRANSFORMATIONS =>
               val res = schedoscope.transformations(config.status, config.filter)
               Await.result(res, TIMEOUT)
-
+            /*
             case QUEUES =>
               val res = schedoscope.queues(config.typ, config.filter)
               Await.result(res, TIMEOUT)
+            */
 
             case VIEWS =>
               val res = schedoscope.views(config.viewUrlPath, config.status, config.filter, config.issueFilter, config.dependencies, config.overview, config.all)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliCommandRunner.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeCliCommandRunner.scala
@@ -56,10 +56,6 @@ class SchedoscopeCliCommandRunner(schedoscope: SchedoscopeService) {
       opt[String]('s', "status") action { (x, c) => c.copy(status = Some(x)) } optional() valueName "<status>" text "filter transformations by their status (e.g. 'queued, running, idle')",
       opt[String]('f', "filter") action { (x, c) => c.copy(filter = Some(x)) } optional() valueName "<regex>" text "regular expression to filter transformation display (e.g. '.*hive-1.*'). ")
 
-    cmd("queues") action { (_, c) => c.copy(action = Some(QUEUES)) } text "list queued actions" children(
-      opt[String]('t', "typ") action { (x, c) => c.copy(typ = Some(x)) } optional() valueName "<type>" text "filter queued actions by their type (e.g. 'oozie', 'filesystem', ...)",
-      opt[String]('f', "filter") action { (x, c) => c.copy(filter = Some(x)) } optional() valueName "<regex>" text "regular expression to filter queued actions (e.g. '.*my.dabatase/myView.*'). ")
-
     cmd("materialize") action { (_, c) => c.copy(action = Some(MATERIALIZE)) } text "materialize view(s)" children(
       opt[String]('s', "status") action { (x, c) => c.copy(status = Some(x)) } optional() valueName "<status>" text "filter views to be materialized by their status (e.g. 'failed')",
       opt[String]('v', "viewUrlPath") action { (x, c) => c.copy(viewUrlPath = Some(x)) } optional() valueName "<viewUrlPath>" text "view url path (e.g. 'my.database/MyView/Partition1/Partition2'). ",
@@ -98,11 +94,6 @@ class SchedoscopeCliCommandRunner(schedoscope: SchedoscopeService) {
             case TRANSFORMATIONS =>
               val res = schedoscope.transformations(config.status, config.filter)
               Await.result(res, TIMEOUT)
-            /*
-            case QUEUES =>
-              val res = schedoscope.queues(config.typ, config.filter)
-              Await.result(res, TIMEOUT)
-            */
 
             case VIEWS =>
               val res = schedoscope.views(config.viewUrlPath, config.status, config.filter, config.issueFilter, config.dependencies, config.overview, config.all)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/listeners/ViewSchedulingMonitor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/listeners/ViewSchedulingMonitor.scala
@@ -32,7 +32,7 @@ class ViewSchedulingMonitor extends ViewSchedulingListener {
     logStateDetails(event)
     logViewSchedulingTimeDeltaOutput(event)
     logScheduledActions(event)
-    
+
   }
 
   def logStateChange(event: ViewSchedulingEvent) =

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/listeners/ViewSchedulingMonitor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/listeners/ViewSchedulingMonitor.scala
@@ -32,8 +32,7 @@ class ViewSchedulingMonitor extends ViewSchedulingListener {
     logStateDetails(event)
     logViewSchedulingTimeDeltaOutput(event)
     logScheduledActions(event)
-
-    storeNewEvent(event)
+    
   }
 
   def logStateChange(event: ViewSchedulingEvent) =

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/messages/Messages.scala
@@ -78,11 +78,6 @@ case class KillCommand() extends CommandRequest
 case class DeployCommand() extends CommandRequest
 
 /**
-  * Used by driver actors to poll the transformation manager actor for a new piece of work to be executed.
-  */
-case class PollCommand(typ: String) extends CommandRequest
-
-/**
   * Tells a driver actor to execute a transformation.
   * @param transformation to execute
   * @param view to transform

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/rest/server/SchedoscopeRestService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/rest/server/SchedoscopeRestService.scala
@@ -72,10 +72,6 @@ class SchedoscopeRestServiceActor(schedoscope: SchedoscopeService) extends Actor
           path("transformations") {
             complete(schedoscope.transformations(status, filter))
           } ~
-          /*
-          path("queues") {
-            complete(schedoscope.queues(typ, filter))
-          } ~ */
           path("views" / Rest.?) { viewUrlPath =>
             complete(schedoscope.views(viewUrlPath, status, filter, issueFilter, dependencies, overview, all))
           } ~

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/rest/server/SchedoscopeRestService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/rest/server/SchedoscopeRestService.scala
@@ -72,9 +72,10 @@ class SchedoscopeRestServiceActor(schedoscope: SchedoscopeService) extends Actor
           path("transformations") {
             complete(schedoscope.transformations(status, filter))
           } ~
+          /*
           path("queues") {
             complete(schedoscope.queues(typ, filter))
-          } ~
+          } ~ */
           path("views" / Rest.?) { viewUrlPath =>
             complete(schedoscope.views(viewUrlPath, status, filter, issueFilter, dependencies, overview, all))
           } ~

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeService.scala
@@ -113,7 +113,7 @@ trait SchedoscopeService {
     *
     * Throws an InvalidArgumentException if an invalid regexp filter is passed.
     */
-  def queues(typ: Option[String], filter: Option[String]): Future[QueueStatusList]
+  //def queues(typ: Option[String], filter: Option[String]): Future[QueueStatusList]
 
   /**
     * Shut down Schedoscope.

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeService.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeService.scala
@@ -109,13 +109,6 @@ trait SchedoscopeService {
   def transformations(status: Option[String], filter: Option[String]): Future[TransformationStatusList]
 
   /**
-    * Returns the transformations waiting in queues. These can be filtered by transformation type or a regexp.
-    *
-    * Throws an InvalidArgumentException if an invalid regexp filter is passed.
-    */
-  //def queues(typ: Option[String], filter: Option[String]): Future[QueueStatusList]
-
-  /**
     * Shut down Schedoscope.
     */
   def shutdown(): Boolean

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -321,6 +321,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
     }
   }
 
+  /*
   def queues(typ: Option[String], filter: Option[String]): Future[QueueStatusList] = {
     val cf = Future(checkFilter(filter))
     cf.flatMap { r =>
@@ -338,6 +339,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
       }
     }
   }
+  */
 
   def shutdown(): Boolean = {
     actorSystem.shutdown()

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -321,26 +321,6 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
     }
   }
 
-  /*
-  def queues(typ: Option[String], filter: Option[String]): Future[QueueStatusList] = {
-    val cf = Future(checkFilter(filter))
-    cf.flatMap { r =>
-      Future {
-        val result = queryActor[QueueStatusListResponse](
-          transformationManagerActor, GetQueues(), settings.schedulingCommandTimeout)
-
-        val queues = result.transformationQueues
-          .filterKeys(t => typ.isEmpty || t.startsWith(typ.get))
-          .map { case (t, queue) => (t, parseQueueElements(queue)) }
-          .map { case (t, queue) => (t, queue.filter(el => filter.isEmpty || el.targetView.matches(filter.get))) }
-        val overview = queues
-          .map(el => (el._1, el._2.size))
-        QueueStatusList(overview, queues)
-      }
-    }
-  }
-  */
-
   def shutdown(): Boolean = {
     actorSystem.shutdown()
     actorSystem.awaitTermination(5 seconds)

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/DriverActorSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/DriverActorSpec.scala
@@ -1,0 +1,182 @@
+/**
+  * Copyright 2015 Otto (GmbH & Co KG)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package org.schedoscope.scheduler.actors
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import test.views.ProductBrand
+import org.schedoscope.dsl.Parameter._
+import org.schedoscope.dsl.transformations.HiveTransformation
+import org.schedoscope.scheduler.messages._
+import org.schedoscope.schema.ddl.HiveQl
+import org.schedoscope.Settings
+
+import scala.util.Random
+import scala.concurrent.duration._
+
+
+class DriverActorSpec extends TestKit(ActorSystem("schedoscope"))
+  with FlatSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  override def afterAll() {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  //common to all tests
+  val view = ProductBrand(p("ec0106"), p("2014"), p("01"), p("01"))
+  val settings = Settings()
+  val transformationManagerActor = TestProbe()
+  val brandViewActor = TestProbe()
+  val productViewActor = TestProbe()
+
+
+  trait HiveActorTest {
+    val hivedriverActor = TestActorRef(DriverActor.props(settings,
+      "hive", transformationManagerActor.ref))
+    transformationManagerActor.expectMsgPF() {
+      case TransformationStatusResponse(msg, actor, driver,
+      driverHandle, driverRunStatus) => {
+        msg shouldBe "idle"
+        actor shouldBe hivedriverActor
+      }
+    }
+  }
+
+  trait DriverActorTest {
+    val Seq(t1, t2, t3) = shuffleTransformations
+    val driverActor1 = launchDriverActor(t1)
+    val driverActor2 = launchDriverActor(t2)
+    val driverActor3 = launchDriverActor(t3)
+
+    def shuffleTransformations:Seq[String] = {
+      val transformations = List("filesystem", "hive",
+        "mapreduce", "noop", "seq")
+      val q = Random.shuffle(transformations)
+        .foldLeft(new collection.mutable.Queue[String]()) {
+          (growingQueue, transformation) =>
+            growingQueue += (transformation)
+        }
+      Seq(q.dequeue, q.dequeue, q.dequeue)
+    }
+
+    def launchDriverActor(transformation:String):ActorRef = {
+      val a = TestActorRef(DriverActor.props(settings,
+        transformation, transformationManagerActor.ref))
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "idle"
+          actor shouldBe a
+        }
+      }
+      a
+    }
+  }
+
+  "All Drivers" should "run DeployCommand" in new DriverActorTest {
+      val cmd = DriverCommand(DeployCommand(), transformationManagerActor.ref)
+      transformationManagerActor.send(driverActor1, cmd)
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "deploy"
+          actor shouldBe driverActor1
+        }
+      }
+      transformationManagerActor.expectMsg(DeployCommandSuccess())
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "idle"
+          actor shouldBe driverActor1
+        }
+      }
+
+      transformationManagerActor.send(driverActor2, cmd)
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "deploy"
+          actor shouldBe driverActor2
+        }
+      }
+      transformationManagerActor.expectMsg(DeployCommandSuccess())
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "idle"
+          actor shouldBe driverActor2
+        }
+      }
+
+      transformationManagerActor.send(driverActor3, cmd)
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "deploy"
+          actor shouldBe driverActor3
+        }
+      }
+      transformationManagerActor.expectMsg(DeployCommandSuccess())
+      transformationManagerActor.expectMsgPF() {
+        case TransformationStatusResponse(msg, actor, driver,
+        driverHandle, driverRunStatus) => {
+          msg shouldBe "idle"
+          actor shouldBe driverActor3
+        }
+      }
+
+    }
+
+  "HiveDriver" should "change state to run hive transformation, " +
+    "kill it, and go back into idle state" in new HiveActorTest {
+
+    val hiveTransformation = new HiveTransformation(HiveQl.ddl(view))
+    val cmd = DriverCommand(TransformView(hiveTransformation, view),
+      transformationManagerActor.ref)
+    transformationManagerActor.send(hivedriverActor, cmd)
+    transformationManagerActor.expectMsgPF() {
+      case TransformationStatusResponse(msg, actor, driver,
+      driverHandle, driverRunStatus) => {
+        msg shouldBe "running"
+        actor shouldBe hivedriverActor
+      }
+    }
+    // A command wrongly sent from transformation manager should be re-enqueued;
+    val cmdThoughBusy = DriverCommand(DeployCommand(), transformationManagerActor.ref)
+    transformationManagerActor.send(hivedriverActor, cmdThoughBusy)
+    transformationManagerActor.expectMsg(cmdThoughBusy)
+
+    // should do nothing!
+    transformationManagerActor.expectNoMsg(3 seconds)
+    // pseudo kill op
+    transformationManagerActor.send(hivedriverActor, KillCommand())
+
+    transformationManagerActor.expectMsgPF() {
+      case TransformationStatusResponse(msg, actor, driver,
+      driverHandle, driverRunStatus) => {
+        msg shouldBe "idle"
+        actor shouldBe hivedriverActor
+      }
+    }
+  }
+
+
+
+}

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/DriverActorSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/DriverActorSpec.scala
@@ -166,13 +166,4 @@ class DriverActorSpec extends TestKit(ActorSystem("schedoscope"))
     }
   }
 
-  "Driver Actors" should "should reply to their original command senders" in {
-    val msgSender = TestProbe()
-    val transformationManagerActor = TestActorRef(new TransformationManagerActor(settings,
-      bootstrapDriverActors = true))
-    val cmd = DriverCommand(DeployCommand(), msgSender.ref)
-    system.actorSelection("akka://schedoscope/user/*") ! cmd
-    msgSender.expectMsg(DeployCommandSuccess())
-  }
-
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
@@ -19,6 +19,11 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
   with BeforeAndAfterAll
   with MockitoSugar {
 
+  // common vars
+  val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
+  lazy val settings = Settings()
+  val myTestActor = TestProbe()
+
   class ForwardChildActor(to: ActorRef) extends Actor {
 
     def receive = {
@@ -27,7 +32,6 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
   }
 
   trait TransformationManagerActorTest {
-    lazy val settings = Settings()
 
     val hiveDriverRouter = TestProbe()
     val mapRedDriverRouter = TestProbe()
@@ -57,13 +61,10 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
     val idleFSStatus = TransformationStatusResponse("idle", fsDriverRouter.ref, null, null, null)
     fsDriverRouter.send(transformationManagerActor, idleFSStatus)
 
-    val baseTransformationStatusList = TransformationStatusListResponse(
-      List(idleSeqStatus, idleNoopStatus, idleFSStatus, idleMapRedStatus, idleHiveStatus ))
   }
 
   it should "forward transformations to the correct DriverManager based on incoming View" in
     new TransformationManagerActorTest {
-      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
       val cmd = DriverCommand(TransformView(testView.transformation(), testView), self)
       transformationManagerActor ! testView
       hiveDriverRouter.expectMsg(cmd)
@@ -83,7 +84,6 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
 
   it should "multicast deployCommand to routers" in
     new TransformationManagerActorTest {
-      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
       val cmd = DriverCommand(DeployCommand(), self)
       //val command = DriverCommand(cmd, self)
       transformationManagerActor ! DeployCommand()
@@ -97,13 +97,22 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
   it should "return the status of transformations (no running transformations)" in
     new TransformationManagerActorTest {
       transformationManagerActor ! GetTransformations()
-      expectMsg(baseTransformationStatusList)
+
+      expectMsgPF() {
+        case TransformationStatusListResponse(statusList) => {
+          statusList.size shouldBe 5
+          statusList should contain(idleHiveStatus)
+          statusList should contain(idleFSStatus)
+          statusList should contain(idleSeqStatus)
+          statusList should contain(idleNoopStatus)
+          statusList should contain(idleMapRedStatus)
+        }
+      }
     }
 
   it should "return the status of transformations" in
     new TransformationManagerActorTest {
 
-      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
       val command = DriverCommand(TransformView(testView.transformation(), testView), self)
       transformationManagerActor ! testView
       hiveDriverRouter.expectMsg(command)
@@ -114,66 +123,29 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
 
       transformationManagerActor ! GetTransformations()
 
-      val newTransformationStatusList = TransformationStatusListResponse(
-        List(idleFSStatus, busyHiveStatus, idleSeqStatus, idleNoopStatus, idleMapRedStatus ))
-
-      expectMsg(newTransformationStatusList)
-
+      expectMsgPF() {
+        case TransformationStatusListResponse(statusList) => {
+          statusList.size shouldBe 5
+          statusList should contain(busyHiveStatus)
+          statusList should contain(idleFSStatus)
+          statusList should contain(idleSeqStatus)
+          statusList should contain(idleNoopStatus)
+          statusList should contain(idleMapRedStatus)
+        }
+      }
     }
 
-  /*
-  "the TransformationManagerActor" should "enqueue a transformation" in new TransformationManagerActorTest {
-    val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
-    transformationManagerActor ! testView
-    transformationManagerActor ! GetQueues()
-    expectMsg(QueueStatusListResponse(Map("filesystem-0" -> List(),
-      "mapreduce" -> List(),
-      "noop" -> List(),
-      "hive" -> List(TransformView(testView.transformation(), testView)),
-      "seq" -> List())))
+  it should "bootstrap driver routers" in {
+    val transformationManagerActor = TestActorRef(new TransformationManagerActor(settings,
+      bootstrapDriverActors = true))
+    Thread.sleep(3000)
+    transformationManagerActor ! GetTransformations()
+    expectMsgPF() {
+      case TransformationStatusListResponse(statusList) => {
+        println(statusList)
+        statusList.size should be > 0
+      }
+    }
   }
-
-  it should "enqueue a deploy command" in new TransformationManagerActorTest {
-    transformationManagerActor ! DeployCommand()
-    transformationManagerActor ! GetQueues()
-    expectMsg(QueueStatusListResponse(Map("filesystem-0" -> List(DeployCommand()),
-      "mapreduce" -> List(DeployCommand()),
-      "noop" -> List(DeployCommand()),
-      "hive" -> List(DeployCommand()),
-      "seq" -> List(DeployCommand()))))
-  }
-
-  it should "enqueue a filesystem transformation" in new TransformationManagerActorTest {
-    transformationManagerActor ! Touch("test")
-    transformationManagerActor ! GetQueues()
-    expectMsg(QueueStatusListResponse(Map("filesystem-0" -> List(Touch("test")),
-      "mapreduce" -> List(),
-      "noop" -> List(),
-      "hive" -> List(),
-      "seq" -> List())))
-  }
-
-  it should "dequeue a transformation" in new TransformationManagerActorTest {
-    val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
-    transformationManagerActor ! testView
-    val command = DriverCommand(TransformView(testView.transformation(), testView), self)
-    transformationManagerActor ! PollCommand("hive")
-    expectMsg(command)
-  }
-
-  it should "dequeue a deploy command" in new TransformationManagerActorTest {
-    transformationManagerActor ! DeployCommand()
-    val command = DriverCommand(DeployCommand(), self)
-    transformationManagerActor ! PollCommand("hive")
-    expectMsg(command)
-  }
-
-  it should "dequeue a filesystem transformation" in new TransformationManagerActorTest {
-    transformationManagerActor ! Touch("test")
-    val command = DriverCommand(Touch("test"), self)
-    transformationManagerActor ! PollCommand("filesystem-0")
-    expectMsg(command)
-  }
-    */
 
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
@@ -142,7 +142,6 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
     transformationManagerActor ! GetTransformations()
     expectMsgPF() {
       case TransformationStatusListResponse(statusList) => {
-        println(statusList)
         statusList.size should be > 0
       }
     }

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/actors/TransformationManagerActorSpec.scala
@@ -1,14 +1,16 @@
 package org.schedoscope.scheduler.actors
-import akka.actor.ActorSystem
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.schedoscope.Settings
 import org.schedoscope.dsl.Parameter._
-import org.schedoscope.dsl.transformations.Touch
+import org.schedoscope.dsl.transformations.{FilesystemTransformation, Touch}
 import org.schedoscope.scheduler.driver.HiveDriver
 import org.schedoscope.scheduler.messages._
 import test.views.ProductBrand
+
+import scala.concurrent.duration._
 
 class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
   with ImplicitSender
@@ -17,15 +19,109 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
   with BeforeAndAfterAll
   with MockitoSugar {
 
+  class ForwardChildActor(to: ActorRef) extends Actor {
+
+    def receive = {
+      case x => to.forward(x)
+    }
+  }
+
   trait TransformationManagerActorTest {
     lazy val settings = Settings()
 
-    val transformationManagerActor = TestActorRef(TransformationManagerActor.props(settings,
-      bootstrapDriverActors = false))
+    val hiveDriverRouter = TestProbe()
+    val mapRedDriverRouter = TestProbe()
+    val noopDriverRouter = TestProbe()
+    val seqDriverRouter = TestProbe()
+    val fsDriverRouter = TestProbe()
 
-    val hiveDriverActor = TestProbe()
+    val transformationManagerActor = TestActorRef(new TransformationManagerActor(settings,
+      bootstrapDriverActors = false) {
+      override def preStart {
+        context.actorOf(Props(new ForwardChildActor(hiveDriverRouter.ref)), "hive-router")
+        context.actorOf(Props(new ForwardChildActor(mapRedDriverRouter.ref)), "mapreduce-router")
+        context.actorOf(Props(new ForwardChildActor(noopDriverRouter.ref)), "noop-router")
+        context.actorOf(Props(new ForwardChildActor(seqDriverRouter.ref)), "seq-router")
+        context.actorOf(Props(new ForwardChildActor(fsDriverRouter.ref)), "filesystem-router")
+      }
+    })
+
+    val idleHiveStatus = TransformationStatusResponse("idle", hiveDriverRouter.ref, null, null, null)
+    hiveDriverRouter.send(transformationManagerActor, idleHiveStatus)
+    val idleMapRedStatus = TransformationStatusResponse("idle", mapRedDriverRouter.ref, null, null, null)
+    mapRedDriverRouter.send(transformationManagerActor, idleMapRedStatus)
+    val idleNoopStatus = TransformationStatusResponse("idle", noopDriverRouter.ref, null, null, null)
+    noopDriverRouter.send(transformationManagerActor, idleNoopStatus)
+    val idleSeqStatus = TransformationStatusResponse("idle", seqDriverRouter.ref, null, null, null)
+    seqDriverRouter.send(transformationManagerActor, idleSeqStatus)
+    val idleFSStatus = TransformationStatusResponse("idle", fsDriverRouter.ref, null, null, null)
+    fsDriverRouter.send(transformationManagerActor, idleFSStatus)
+
+    val baseTransformationStatusList = TransformationStatusListResponse(
+      List(idleSeqStatus, idleNoopStatus, idleFSStatus, idleMapRedStatus, idleHiveStatus ))
   }
 
+  it should "forward transformations to the correct DriverManager based on incoming View" in
+    new TransformationManagerActorTest {
+      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
+      val cmd = DriverCommand(TransformView(testView.transformation(), testView), self)
+      transformationManagerActor ! testView
+      hiveDriverRouter.expectMsg(cmd)
+
+    }
+
+  it should "forward transformations to the correct DriverManager based on incoming Transformation" in
+    new TransformationManagerActorTest {
+      val filesystemTransformation = new FilesystemTransformation
+      val cmd = DriverCommand(filesystemTransformation, self)
+      //val command = DriverCommand(cmd, self)
+      transformationManagerActor ! filesystemTransformation
+      fsDriverRouter.expectMsg(cmd)
+      hiveDriverRouter.expectNoMsg(3 seconds)
+
+    }
+
+  it should "multicast deployCommand to routers" in
+    new TransformationManagerActorTest {
+      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
+      val cmd = DriverCommand(DeployCommand(), self)
+      //val command = DriverCommand(cmd, self)
+      transformationManagerActor ! DeployCommand()
+      hiveDriverRouter.expectMsg(cmd)
+      mapRedDriverRouter.expectMsg(cmd)
+      noopDriverRouter.expectMsg(cmd)
+      seqDriverRouter.expectMsg(cmd)
+      fsDriverRouter.expectMsg(cmd)
+    }
+
+  it should "return the status of transformations (no running transformations)" in
+    new TransformationManagerActorTest {
+      transformationManagerActor ! GetTransformations()
+      expectMsg(baseTransformationStatusList)
+    }
+
+  it should "return the status of transformations" in
+    new TransformationManagerActorTest {
+
+      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
+      val command = DriverCommand(TransformView(testView.transformation(), testView), self)
+      transformationManagerActor ! testView
+      hiveDriverRouter.expectMsg(command)
+
+      val busyHiveStatus = TransformationStatusResponse("running", hiveDriverRouter.ref,
+        HiveDriver(settings.getDriverSettings("hive")), null, null)
+      hiveDriverRouter.send(transformationManagerActor, busyHiveStatus)
+
+      transformationManagerActor ! GetTransformations()
+
+      val newTransformationStatusList = TransformationStatusListResponse(
+        List(idleFSStatus, busyHiveStatus, idleSeqStatus, idleNoopStatus, idleMapRedStatus ))
+
+      expectMsg(newTransformationStatusList)
+
+    }
+
+  /*
   "the TransformationManagerActor" should "enqueue a transformation" in new TransformationManagerActorTest {
     val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
     transformationManagerActor ! testView
@@ -78,29 +174,6 @@ class TransformationManagerActorSpec extends TestKit(ActorSystem("schedoscope"))
     transformationManagerActor ! PollCommand("filesystem-0")
     expectMsg(command)
   }
-
-  it should "return the status of transformations (no running transformations)" in
-    new TransformationManagerActorTest {
-      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
-      transformationManagerActor ! testView
-      transformationManagerActor ! GetTransformations()
-      expectMsg(TransformationStatusListResponse(List()))
-    }
-
-  it should "return the status of transformations" in
-    new TransformationManagerActorTest {
-      val testView = ProductBrand(p("1"), p("2"), p("3"), p("4"))
-      val command = DriverCommand(TransformView(testView.transformation(), testView), self)
-      transformationManagerActor ! testView
-      transformationManagerActor ! PollCommand("hive")
-      expectMsg(command)
-      transformationManagerActor ! GetTransformations()
-      expectMsg(TransformationStatusListResponse(List()))
-      val transformationStatusResponse = TransformationStatusResponse("running", hiveDriverActor.ref, HiveDriver(settings.getDriverSettings("hive")), null, null)
-      transformationManagerActor ! transformationStatusResponse
-      transformationManagerActor ! GetTransformations()
-      expectMsg(TransformationStatusListResponse(List(transformationStatusResponse)))
-    }
-
+    */
 
 }

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImplSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImplSpec.scala
@@ -833,7 +833,7 @@ class SchedoscopeServiceImplSpec extends TestKit(ActorSystem("schedoscope"))
     * filter=Regexp apply a regular expression filter on driver name (e.g. '?filter=.hive.')
     *
     */
-
+  /*
   it should "ask transformationManagerActor for ongoing queues" in new SchedoscopeServiceTest {
     val prodBrandviewUrlPath01 = Some(prodBrandUrl01)
     val typParam = None
@@ -852,6 +852,7 @@ class SchedoscopeServiceImplSpec extends TestKit(ActorSystem("schedoscope"))
     response.value.get.get.overview shouldBe Map("allFakeActors" -> 2)
     response.value.get.get.queues.get("allFakeActors").get.size shouldBe 2
   }
+  */
 
   /**
     * Testing /transformations

--- a/schedoscope-core/src/test/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImplSpec.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImplSpec.scala
@@ -144,7 +144,7 @@ class SchedoscopeServiceImplSpec extends TestKit(ActorSystem("schedoscope"))
     val schemaManagerActor = TestProbe()
     val transformationManagerActor = TestProbe()
 
-    // view actors (spawn by ViewManagerActor
+    // view actors (spawn by ViewManagerActor)
     lazy val prodBrandViewActor = TestProbe()
     lazy val prodViewActor = TestProbe()
     lazy val brandViewActor = TestProbe()
@@ -823,36 +823,6 @@ class SchedoscopeServiceImplSpec extends TestKit(ActorSystem("schedoscope"))
     response.value.get.get.views(0).viewPath shouldBe prodBrandUrl01 + s"/${year}${month}${day}"
     response.value.get.get.views(0).dependencies shouldBe None
   }
-
-  /**
-    * Testing /queues
-    *
-    * /queues parameters:
-    *
-    * status=(running|idle) passing this parameter will further restrict the output to transformation drivers with the given state.
-    * filter=Regexp apply a regular expression filter on driver name (e.g. '?filter=.hive.')
-    *
-    */
-  /*
-  it should "ask transformationManagerActor for ongoing queues" in new SchedoscopeServiceTest {
-    val prodBrandviewUrlPath01 = Some(prodBrandUrl01)
-    val typParam = None
-    val filterParam = None
-    val response = service.queues(typParam, filterParam)
-
-    transformationManagerActor.expectMsg(DeployCommand())
-    transformationManagerActor.expectMsg(GetQueues())
-
-    val queueMsgStatus = QueueStatusListResponse(Map("allFakeActors" -> List(TestProbe().ref, TestProbe().ref)))
-    transformationManagerActor.reply(queueMsgStatus)
-
-    Await.result(response, TIMEOUT)
-
-    response.isCompleted shouldBe true
-    response.value.get.get.overview shouldBe Map("allFakeActors" -> 2)
-    response.value.get.get.queues.get("allFakeActors").get.size shouldBe 2
-  }
-  */
 
   /**
     * Testing /transformations


### PR DESCRIPTION
@utzwestermann @lofifnc

PR goal:
- Remove Queue system in TransformationManagerActor

PR summary:
- Substituted queue with one Router actor - SmallestMailboxPool - per Driver Type, which by itself spawns & manages correspondent Drivers as children;
- Maintained 2 state condition of DriverActor, which only triggers constant ticking for "running" state;
- Maintained Logging logic in TransformationManagerActor, to minimize disruption;
- Updated "front-end" service API (CLI + Spray API) to reflect consequent Queue feature removal;
- Updated Wiki in: https://github.com/diogoaurelio/schedoscopeWiki/pull/4

Notes:
- Had issue with with BalancingPool: https://groups.google.com/forum/#!topic/akka-user/8roVP58f49U ; choose alternative working solution SmallestMailboxPool Router;