### PR TITLE
Metascope uses schedoscope host from config-file

### DIFF
--- a/schedoscope-metascope/src/main/java/org/schedoscope/metascope/conf/MetascopeConfig.java
+++ b/schedoscope-metascope/src/main/java/org/schedoscope/metascope/conf/MetascopeConfig.java
@@ -79,7 +79,7 @@ public class MetascopeConfig {
 
         this.port = config.metascopePort();
 
-        this.schedoscopeHost = "localhost";
+        this.schedoscopeHost = config.host();
         this.schedoscopePort = config.port();
 
         this.authenticationMethod = getString(config.metascopeAuthMethod());


### PR DESCRIPTION
MetascopeConfig sets the schedoscope host to the configured value from the
configuration file instead of the hard-coded value 'localhost'.