### PR TITLE
Added hadoop classpath for metascope execution

### DIFF
--- a/schedoscope-metascope/src/main/resources/start-metascope.sh
+++ b/schedoscope-metascope/src/main/resources/start-metascope.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 CP=""
 for D in lib/*.jar; do CP=${CP}:${D}; done
+CP=${CP}:`hadoop classpath`
 CP=${CP}:metascope.jar
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
The hadoop configuration files are usually on the hadoop classpath, thus
we can use the configuration for our hadoop cluster.