### PR TITLE
Put CLI REPL history file in $XDG_CACHE_HOME defaulting to $HOME/.cache

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeReplCli.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/commandline/SchedoscopeReplCli.scala
@@ -28,7 +28,8 @@ class SchedoscopeCliRepl(val schedoscope: SchedoscopeService) {
     val ctrl = new SchedoscopeCliCommandRunner(schedoscope)
     val reader = new ConsoleReader()
     val history = new History()
-    history.setHistoryFile(new File(System.getenv("HOME") + "/.schedoscope_history"))
+    val histFileDir = Option(System.getenv("XDG_CACHE_HOME")).getOrElse(System.getenv("HOME") + "/.cache")
+    history.setHistoryFile(new File(histFileDir + "/schedoscope_history"))
     reader.setHistory(history)
     while (true) {
       try {


### PR DESCRIPTION
Fixes #145 