### PR TITLE
Implement two-step process for creation of Calcite schema, also...

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/lineage/DependencyAnalyzer.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/lineage/DependencyAnalyzer.scala
@@ -19,6 +19,7 @@ package org.schedoscope.lineage
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core._
 import org.apache.calcite.rex._
+import org.apache.calcite.tools.ValidationException
 import org.schedoscope.dsl.transformations.HiveTransformation
 import org.schedoscope.dsl.transformations.Transformation.replaceParameters
 import org.schedoscope.dsl.{FieldLike, View}
@@ -98,9 +99,9 @@ object DependencyAnalyzer {
   private def getMap(view: View, ht: HiveTransformation, depFunc: DependencyFunction): DependencyMap = {
     log.debug("Processing lineage of {}", view)
 
-    val planner = new NonFlatteningPlannerImpl(SchedoscopeConfig(view))
+    var planner = new NonFlatteningPlannerImpl(SchedoscopeConfig(view, scanRecursive = false))
 
-    (((Some(ht.sql)
+    val firstStmt = (Some(ht.sql)
       map (replaceParameters(_, ht.configuration.toMap))
       map { sql => replaceParameters(sql, parseHiveVars(sql)) }
       map preprocessSql
@@ -110,20 +111,32 @@ object DependencyAnalyzer {
         case None => sql
       }
     }
-      map planner.parse
-      map planner.validate
-      map planner.convert
-      map depFunc
-      get) zipWithIndex)
-      map { case (set, i) => view.fields(i) -> set } toMap)
+      ).get
+
+    val parsed = planner.parse(firstStmt)
+
+    // try with direct dependencies first, then recursively
+    val validated = try {
+      planner.validate(parsed)
+    } catch {
+      case _: ValidationException =>
+        log.debug("Trying again with a recursively-built schema...")
+        planner = new NonFlatteningPlannerImpl(SchedoscopeConfig(view, scanRecursive = true))
+        planner.validate(planner.parse(firstStmt))
+    }
+
+    val relNode = planner.convert(validated)
+    depFunc(relNode).zipWithIndex.map {
+      case (set, i) => view.fields(i) -> set
+    }.toMap
   }
 
   /**
-    * Provides dependency information for a [[RelNode]].
+    * Provides dependency information for a [[org.apache.calcite.rel.RelNode]].
     * <p>
-    * In addition to all dependencies found by [[DependencyAnalyzer.lineageOf()]], the following dependencies are added:
+    * In addition to all dependencies found by `lineageOf()`, the following dependencies are added:
     * <ul>
-    *   <li>`JOIN`, `FILTER`: Lineage of the condition's [[RexNode]] is added to all output attributes' lineage</li>
+    * <li>`JOIN`, `FILTER`: Lineage of the condition's [[org.apache.calcite.rel.RelNode]] is added to all output attributes' lineage</li>
     *   <li>`AGGREGATE`: Lineage of all group set members is added to all aggregated attributes' lineage</li>
     * </ul>
     *
@@ -164,7 +177,7 @@ object DependencyAnalyzer {
   }
 
   /**
-    * Provides lineage information for a [[RelNode]].
+    * Provides lineage information for a [[org.apache.calcite.rel.RelNode]].
     * <p>
     * <ul>
     *   <li>`TABLESCAN`: Trivial leaf case, each attribute depends on itself</li>
@@ -206,10 +219,11 @@ object DependencyAnalyzer {
   }
 
   /**
-    * Provides lineage information for a [[RexNode]].
+    * Provides lineage information for a [[org.apache.calcite.rex.RexNode]].
     * <p>
-    * The [[RexNode]] is analyzed recursively with its operands, if a [[RexCall]] is found.
-    * In case of an [[RexInputRef]], the referenced field index is returned.
+    * The [[org.apache.calcite.rex.RexNode]] is analyzed recursively with its operands, if a
+    * [[org.apache.calcite.rex.RexCall]] is found. In case of an [[org.apache.calcite.rex.RexInputRef]],
+    * the referenced field index is returned.
     *
     * @param node the node to analyze
     * @return A list of field indices from the input relation the node depends on
@@ -224,7 +238,7 @@ object DependencyAnalyzer {
   /**
     * Provides lineage information for black box transformations.
     * <p>
-    * If an explicit lineage for a field has been defined with [[View.affects()]], the information is taken from
+    * If an explicit lineage for a field has been defined with `View.affects()`, the information is taken from
     * there. Otherwise, it is assumed, that each field depends on <i>every</i> field from each dependency.
     * <p>
     * If a view does not depend on any views, will return a map where each field depends only on itself.

--- a/schedoscope-core/src/main/scala/org/schedoscope/lineage/SchedoscopeConfig.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/lineage/SchedoscopeConfig.scala
@@ -37,10 +37,10 @@ import scala.collection.JavaConverters._
 /**
   * @author Jan Hicken (jhicken)
   */
-case class SchedoscopeConfig(view: View) extends FrameworkConfig {
+case class SchedoscopeConfig(view: View, scanRecursive: Boolean) extends FrameworkConfig {
   override val getDefaultSchema: SchemaPlus = {
     val rootSchema = Frameworks.createRootSchema(false)
-    view.recursiveDependencies.groupBy(_.dbName).foreach {
+    (if (scanRecursive) view.recursiveDependencies else view.dependencies).groupBy(_.dbName).foreach {
       case (dbName, dbViews) => rootSchema.add(dbName, SchedoscopeSchema(dbViews))
     }
 


### PR DESCRIPTION
 - let ScalaDoc have its fully-qualified class names because it's too dumb to respect imports
 - simplify the getMap method a little bit, because it has been rather complicated to read

This should fix #151.