### PR TITLE
Set View for Transformation in transformVia()

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -295,7 +295,6 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
     */
   override def transformVia(ft: () => Transformation) {
     ensureRegisteredParameters
-    ft().forView(this)
 
     registeredTransformation = ft
   }

--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/View.scala
@@ -295,6 +295,7 @@ abstract class View extends Structure with ViewDsl with DelayedInit {
     */
   override def transformVia(ft: () => Transformation) {
     ensureRegisteredParameters
+    ft().forView(this)
 
     registeredTransformation = ft
   }

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/DriverActor.scala
@@ -239,7 +239,7 @@ class DriverActor[T <: Transformation](transformationManagerActor: ActorRef,
           logStateInfo("idle", "DRIVER ACTOR: becoming idle")
           runningCommand = None
         case TransformView(t, view) =>
-          val transformation: T = t.asInstanceOf[T]
+          val transformation: T = t.forView(view).asInstanceOf[T]
 
           val runHandle = driver.run(transformation)
           driver.driverRunStarted(runHandle)

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TransformationManagerActor.scala
@@ -130,7 +130,7 @@ class TransformationManagerActor(settings: SchedoscopeSettings,
       }
 
     case viewToTransform: View =>
-      val transformation = viewToTransform.transformation().forView(viewToTransform)
+      val transformation = viewToTransform.transformation()
       val commandRequest = DriverCommand(TransformView(transformation, viewToTransform), sender)
       context.actorSelection(s"${self.path}/${transformation.name}-driver") forward commandRequest
 


### PR DESCRIPTION
The view variable in a Transformation gets only set if a done explicitly.
This will register the corresponding View for a Transformation during the transformVia() call.

This ensures the name of the view is shown in the resource manager. 