### PR TITLE
Allow for nested Stubbing

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TableActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/TableActor.scala
@@ -232,8 +232,11 @@ class TableActor(currentStates: Map[View, ViewSchedulingState],
             sendMessageToView(view, MaterializeExternalView(mode))
           }
         } else if (settings.developmentModeEnabled &&
-           settings.viewsUnderDevelopment.contains(currentState.view.urlPathPrefix)) {
+          settings.viewsUnderDevelopment.contains(currentState.view.urlPathPrefix) &&
+          !settings.viewsUnderDevelopment.contains(view.urlPathPrefix)) {
+
           log.info(s"View is in development $view")
+
           //stub the dependent view
           sendMessageToView(view, MaterializeViewAsStub())
         } else {

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/actors/ViewManagerActor.scala
@@ -267,7 +267,13 @@ object ViewManagerActor {
       } else {
         visited.add(v)
         if (settings.developmentModeEnabled && settings.viewsUnderDevelopment.contains(v.urlPathPrefix)) {
-          v :: v.dependencies
+          val viewsUnderDev = settings.viewsUnderDevelopment
+          val (normalViews, stubbedViews) = v.dependencies.partition(v => viewsUnderDev.contains(v.urlPathPrefix))
+          if(normalViews.isEmpty) {
+            v :: v.dependencies
+          } else {
+            v :: stubbedViews ::: unknownViewsOrDependencies(normalViews, vsm, visited)
+          }
         } else {
           v :: unknownViewsOrDependencies(v.dependencies, vsm, visited)
         }

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -100,7 +100,19 @@ case class ProductBrandClick(shopCode: Parameter[String],
                              day: Parameter[String]) extends View {
 
   val productBrand = dependsOn(() => ProductBrand(shopCode, year, month, day))
-  val click = dependsOn(() => Click(shopCode, year, month, day))
+  val click = dependsOn(() => NestedClick(shopCode, year, month, day))
+}
+
+case class NestedClick(shopCode: Parameter[String],
+                      year: Parameter[String],
+                      month: Parameter[String],
+                      day: Parameter[String]) extends View
+  with Id
+  with DailyParameterization {
+
+  dependsOn(() => Click(shopCode, year, month, day))
+
+  val url = fieldOf[String]
 }
 
 case class ViewWithIllegalExternalDeps(shopCode: Parameter[String]) extends View {
@@ -115,6 +127,8 @@ case class ViewWithIllegalExternalDeps(shopCode: Parameter[String]) extends View
       this,
       s"""SELECT * FROM ${shop().n}""")))
 }
+
+
 
 case class ViewWithIllegalInternalDeps(shopCode: Parameter[String]) extends View {
 

--- a/schedoscope-core/src/test/scala/test/views/TestViews.scala
+++ b/schedoscope-core/src/test/scala/test/views/TestViews.scala
@@ -128,8 +128,6 @@ case class ViewWithIllegalExternalDeps(shopCode: Parameter[String]) extends View
       s"""SELECT * FROM ${shop().n}""")))
 }
 
-
-
 case class ViewWithIllegalInternalDeps(shopCode: Parameter[String]) extends View {
 
   val shop = dependsOn(() => ExternalShop())


### PR DESCRIPTION
Schedoscope does now recognize if a dependency of a view under development, is under development.
In this case the view will not be instructed to do a copy. Instead it will receive a default materialize request.