### PR TITLE
Splitting Schedoscope views service call with Option all

### DIFF
--- a/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Export.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/dsl/transformations/Export.scala
@@ -16,6 +16,8 @@
 
 package org.schedoscope.dsl.transformations
 
+import java.util.UUID
+
 import org.apache.hadoop.mapreduce.Job
 import org.schedoscope.Schedoscope
 import org.schedoscope.dsl.{Field, View}
@@ -339,7 +341,7 @@ object Export {
     t.configureWith(
       Map(
         "schedoscope.export.storageBucket" -> storageBucket,
-        "schedoscope.export.storageBucketFolderPrefix" -> storageBucketFolderPrefix,
+        "schedoscope.export.storageBucketFolderPrefix" -> s"${storageBucketFolderPrefix}${if (storageBucketFolderPrefix != "") "/" else ""}${UUID.randomUUID().toString}",
         "schedoscope.export.storageBucketRegion" -> storageBucketRegion,
         "schedoscope.export.dataLocation" -> dataLocation,
         "schedoscope.export.numReducers" -> numReducers,

--- a/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
+++ b/schedoscope-core/src/main/scala/org/schedoscope/scheduler/service/SchedoscopeServiceImpl.scala
@@ -159,7 +159,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
                                                 issueFilter: Option[String]
                                                ) = {
 
-    val viewStatusListWithoutViewDetails = viewStatusResponses.map { v =>
+    lazy val viewStatusListWithoutViewDetails = viewStatusResponses.map { v =>
       viewStatusOutput(vsr = v,
         viewTableName = if (all.getOrElse(false)) Some(v.view.tableName) else None,
         isTable = if (all.getOrElse(false)) Some(false) else None,
@@ -184,7 +184,7 @@ class SchedoscopeServiceImpl(actorSystem: ActorSystem, settings: SchedoscopeSett
             issueFilter
           )
         )
-        .toList ::: viewStatusListWithoutViewDetails
+        .toList
     else
       viewStatusListWithoutViewDetails
 

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/ExportTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/ExportTest.scala
@@ -39,8 +39,8 @@ import scala.collection.JavaConverters._
 
 class ExportTest extends FlatSpec with Matchers with BeforeAndAfter {
 
-  private val CALL_BIG_QUERY = false
-  private val CLEAN_UP_BIG_QUERY = true
+  private val CALL_BIG_QUERY = true
+  private val CLEAN_UP_BIG_QUERY = false
 
   before {
     if (CALL_BIG_QUERY) {

--- a/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/ExportTest.scala
+++ b/schedoscope-core/src/test/scala/org/schedoscope/dsl/transformations/ExportTest.scala
@@ -39,8 +39,8 @@ import scala.collection.JavaConverters._
 
 class ExportTest extends FlatSpec with Matchers with BeforeAndAfter {
 
-  private val CALL_BIG_QUERY = true
-  private val CLEAN_UP_BIG_QUERY = false
+  private val CALL_BIG_QUERY = false
+  private val CLEAN_UP_BIG_QUERY = true
 
   before {
     if (CALL_BIG_QUERY) {

--- a/schedoscope-export/src/main/java/org/schedoscope/export/utils/BigQueryUtils.java
+++ b/schedoscope-export/src/main/java/org/schedoscope/export/utils/BigQueryUtils.java
@@ -247,7 +247,7 @@ public class BigQueryUtils {
         LoadJobConfiguration configuration = LoadJobConfiguration
                 .newBuilder(table, cloudStoragePathsToData)
                 .setFormatOptions(FormatOptions.json())
-                .setWriteDisposition(WriteDisposition.WRITE_EMPTY)
+                .setWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
                 .build();
 
         //jobId could be used to reference the job later
@@ -259,9 +259,9 @@ public class BigQueryUtils {
         try {
             loadJob = loadJob.waitFor();
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            throw new BigQueryException(999, "Caught exception while inserting records into BigTable ", e);
         } catch (TimeoutException e) {
-            e.printStackTrace();
+            throw new BigQueryException(999, "Caught exception while inserting records into BigTable ", e);
         }
 
         if (loadJob.getStatus().getError() != null) {


### PR DESCRIPTION
When views operation is called in SchedoscopeServiceImpl with option all set, only aggregate table data is returned and not view data. To obtain view data, issue  a second call without the all option.

Also, when exporting to BigQuery, a UUID path prefix is used for storing exported data in Cloud Storage. This avoids clashes with remnants of terminated previous job runs, which in turn may result in data duplication.